### PR TITLE
Add CI using GitHub Actions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,13 @@
+[run]
+branch = True
+source = func_adl
+
+[report]
+exclude_lines =
+    if self.debug:
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == .__main__.:
+ignore_errors = True
+omit =
+    tests/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI/CD
+
+on:
+  push:
+  pull_request:
+  # Run daily at 0:01 UTC
+  schedule:
+  - cron:  '1 0 * * *'
+
+jobs:
+  test:
+
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macOS-latest, windows-latest]
+        python-version: [3.6, 3.7]
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        pip install --no-cache-dir -e .
+        pip install --no-cache-dir pytest pytest-cov flake8 coverage codecov
+        pip list
+    - name: Lint with Flake8
+      if: matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
+      run: |
+        flake8 --exclude=tests/* --ignore=E501
+    - name: Test with pytest
+      run: |
+        python -m pytest -r sx
+    - name: Report coverage with Codecov
+      if: github.event_name == 'push' && matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
+      run: |
+        codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ python:
 - '3.7'
 install:
 - pip install -e .
-- pip install pytest coverage codecov flake8
+- pip install pytest pytest-cov coverage codecov flake8
 script:
 - flake8 --exclude=tests/* --ignore=E501
-- coverage run -m pytest -s
-- codecov
+- python -m pytest -r sx

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --ignore=setup.py --cov=func_adl --cov-report=term-missing --cov-config=.coveragerc --cov-report xml


### PR DESCRIPTION
* Test Python 3.6 and Python 3.7 across Ubuntu, MacOS, and Windows using GitHub Actions CI
* Add `pytest-cov` dependency
* Add pytest.ini and .coveragerc to simplify signatures

Additionally remove codecov reporting on Travis so that you don't run into an issue with two coverage reports being uploaded.