### PR TITLE
Use Codecov GitHub actions app to report coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ on:
 jobs:
   test:
 
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        platform: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.6, 3.7]
-    runs-on: ${{ matrix.platform }}
 
     steps:
     - uses: actions/checkout@master
@@ -28,13 +28,13 @@ jobs:
         pip install --no-cache-dir -e .[complete]
         pip list
     - name: Lint with Flake8
-      if: matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
+      if: matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
       run: |
         flake8 --exclude=tests/* --ignore=E501
     - name: Test with pytest
       run: |
         python -m pytest -r sx
     - name: Report coverage with Codecov
-      if: github.event_name == 'push' && matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
+      if: github.event_name == 'push' && matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
       run: |
         codecov --token=${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,8 @@ jobs:
         python -m pytest -r sx
     - name: Report coverage with Codecov
       if: github.event_name == 'push' && matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
-      run: |
-        codecov --token=${{ secrets.CODECOV_TOKEN }}
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml
+        flags: unittests


### PR DESCRIPTION
To fix the reporting of coverage (I'm not sure what happened that it broke, as it is a bit hard to trace things at the moment &mdash; probably from an old PR of mine not getting rebased before merge) use the [GitHub Actions Codecov](https://github.com/marketplace/actions/codecov) app to upload and report the coverage.

c.f. https://github.com/codecov/codecov-action

This seems to be the more supported solution then using https://github.com/codecov/codecov-python.