### PR TITLE
use relative imports

### DIFF
--- a/func_adl/EventDataset.py
+++ b/func_adl/EventDataset.py
@@ -1,8 +1,8 @@
 # Event dataset
 from urllib import parse
 from urllib.parse import ParseResult
-from func_adl import ObjectStream
-from func_adl.util_ast import function_call, as_ast
+from .ObjectStream import ObjectStream
+from .util_ast import function_call, as_ast
 from typing import Union, Iterable
 
 

--- a/func_adl/ObjectStream.py
+++ b/func_adl/ObjectStream.py
@@ -1,6 +1,6 @@
 # An Object stream represents a stream of objects, floats, integers, etc.
-from func_adl.util_ast_LINQ import parse_as_ast
-from func_adl.util_ast import as_ast, function_call
+from .util_ast_LINQ import parse_as_ast
+from .util_ast import as_ast, function_call
 # import ast
 from typing import Any, Callable, cast, Union
 import asyncio

--- a/func_adl/util_ast_LINQ.py
+++ b/func_adl/util_ast_LINQ.py
@@ -1,6 +1,6 @@
 # Helpers for LINQ operators and LINQ expressions in AST form.
 # Utility routines to manipulate LINQ expressions.
-from func_adl.util_ast import lambda_unwrap
+from .util_ast import lambda_unwrap
 import ast
 from typing import Union
 


### PR DESCRIPTION
I generally prefer to use explicit relative imports rather than absolute imports for anything within the same package. I looked into this in more detail, and at this point neither option seems to be strongly recommended over the other, so I suppose this is mostly a stylistic choice. I like the relative imports because you can import a package or module from anywhere without having to install it or mess with `sys.path` (this was the issue that led me to look at this). They also mean you can change the name of the package without modifying the files within the package.