### PR TITLE
Updat naming (#33)

### DIFF
--- a/func_adl/__init__.py
+++ b/func_adl/__init__.py
@@ -6,7 +6,7 @@
 # just turn off checking here.
 
 # Main streaming object
-from .ObjectStream import ObjectStream, ObjectStreamException  # NOQA
+from .object_stream import ObjectStream, ObjectStreamException  # NOQA
 
 # Dataset accessors
-from .EventDataset import EventDataset, EventDatasetURLException  # NOQA
+from .event_dataset import EventDataset, EventDatasetURLException  # NOQA

--- a/func_adl/event_dataset.py
+++ b/func_adl/event_dataset.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 import ast
 from typing import Any, Optional, cast, List
 
-from .ObjectStream import ObjectStream
+from .object_stream import ObjectStream
 from .util_ast import function_call
 
 

--- a/func_adl/object_stream.py
+++ b/func_adl/object_stream.py
@@ -122,7 +122,7 @@ class ObjectStream:
         if executor is not None:
             return executor
 
-        from .EventDataset import find_ed_in_ast
+        from .event_dataset import find_ed_in_ast
         ed = find_ed_in_ast(self._ast)
 
         return ed.execute_result_async

--- a/tests/test_event_dataset.py
+++ b/tests/test_event_dataset.py
@@ -4,7 +4,7 @@ from typing import Any
 import pytest
 
 from func_adl import EventDataset
-from func_adl.EventDataset import find_ed_in_ast
+from func_adl.event_dataset import find_ed_in_ast
 
 def test_cannot_create():
     with pytest.raises(Exception):

--- a/tests/test_object_stream.py
+++ b/tests/test_object_stream.py
@@ -1,7 +1,7 @@
 # Test the object stream
 import sys
 sys.path += ['.']
-from func_adl import ObjectStream, ObjectStreamException, EventDatasetURLException, EventDataset
+from func_adl import EventDataset
 import ast
 import asyncio
 import pytest


### PR DESCRIPTION

Move to a system where the object we have is not the same name as the file.

Fixes #33