### PR TITLE
add a query_ast property to ObjectStream for access.

### DIFF
--- a/func_adl/event_dataset.py
+++ b/func_adl/event_dataset.py
@@ -20,7 +20,7 @@ class EventDataset(ObjectStream, ABC):
         # We participate in the AST parsing - as a node. This argument is used in a lookup
         # later on - so do not alter this in a subclass without understanding what is
         # going on!
-        self._ast = function_call('EventDataset', [ast.Constant(value=self)])
+        super().__init__(function_call('EventDataset', [ast.Constant(value=self)]))
 
     def __repr__(self):
         return f"'{self.__class__.__name__}'"

--- a/tests/test_event_dataset.py
+++ b/tests/test_event_dataset.py
@@ -1,5 +1,5 @@
 import ast
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -20,7 +20,7 @@ class my_event(EventDataset):
 class my_event_extra_args(EventDataset):
     def __init__(self):
         super().__init__()
-        self._ast.args.append(ast.Str(s='hi'))
+        cast(ast.Call, self.query_ast).args.append(ast.Str(s='hi'))
 
     async def execute_result_async(self, a: ast.AST) -> Any:
         return 10
@@ -32,18 +32,18 @@ def test_can_create():
 
 def test_find_event_at_top():
     e = my_event()
-    assert find_ed_in_ast(e._ast) is e
+    assert find_ed_in_ast(e.query_ast) is e
 
 
 def test_find_event_inside():
     e = my_event()
-    add = ast.BinOp(ast.Num(5), ast.Add, e._ast)
+    add = ast.BinOp(ast.Num(5), ast.Add, e.query_ast)
     assert find_ed_in_ast(add) is e
 
 
 def test_find_event_with_more_ast():
     e = my_event_extra_args()
-    add = ast.BinOp(ast.Num(5), ast.Add, e._ast)
+    add = ast.BinOp(ast.Num(5), ast.Add, e.query_ast)
     assert find_ed_in_ast(add) is e
 
 

--- a/tests/test_object_stream.py
+++ b/tests/test_object_stream.py
@@ -84,6 +84,18 @@ async def test_await_exe_from_normal_function():
         .value_async()
     assert isinstance(await r, ast.AST)
 
+
+def test_ast_prop():
+    r = my_event() \
+        .SelectMany("lambda e: e.jets()") \
+        .Select("lambda j: j.pT()") \
+        .AsROOTTTree("junk.root", "analysis", "jetPT")
+
+    assert isinstance(r.query_ast, ast.AST)
+    assert isinstance(r.query_ast, ast.Call)
+
+
+
 @pytest.mark.asyncio
 async def test_2await_exe_from_coroutine():
     r1 = my_event() \


### PR DESCRIPTION
- Also will break anyone's direct internal access to the `_ast` variable, forcing them to update to use the public API
Fixes #39