### PR TITLE
Parse Lambda's inline

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -46,5 +46,8 @@
     "python.analysis.openFilesOnly": false,
     "python.pythonPath": ".venv\\Scripts\\python.exe",
     "python.venvPath": ".venv",
-    "python.analysis.typeCheckingMode": "basic"
+    "python.analysis.typeCheckingMode": "basic",
+    "python.testing.pytestArgs": [
+        "--no-cov"
+    ]
 }

--- a/func_adl/object_stream.py
+++ b/func_adl/object_stream.py
@@ -43,7 +43,7 @@ class ObjectStream:
         '''
         return self._q_ast
 
-    def SelectMany(self, func: Union[str, ast.Lambda]) -> 'ObjectStream':
+    def SelectMany(self, func: Union[str, ast.Lambda, Callable]) -> 'ObjectStream':
         r"""
         Given the current stream's object type is an array or other iterable, return
         the items in this objects type, one-by-one. This has the effect of flattening a
@@ -56,10 +56,14 @@ class ObjectStream:
 
         Returns:
             A new ObjectStream of the type of the elements.
+
+        Notes:
+            - The function can be a `lambda`, the name of a one-line function, a string that contains
+              a lambda definition, or a python `ast` of type `ast.Lambda`.
         """
         return ObjectStream(function_call("SelectMany", [self._q_ast, cast(ast.AST, parse_as_ast(func))]))
 
-    def Select(self, f: Union[str, ast.Lambda]) -> 'ObjectStream':
+    def Select(self, f: Union[str, ast.Lambda, Callable]) -> 'ObjectStream':
         r"""
         Apply a transformation function to each object in the stream, yielding a new type of
         object. There is a one-to-one correspondence between the input objects and output objects.
@@ -71,10 +75,14 @@ class ObjectStream:
         Returns:
 
             A new ObjectStream of the transformed elements.
+
+        Notes:
+            - The function can be a `lambda`, the name of a one-line function, a string that contains
+              a lambda definition, or a python `ast` of type `ast.Lambda`.
         """
         return ObjectStream(function_call("Select", [self._q_ast, cast(ast.AST, parse_as_ast(f))]))
 
-    def Where(self, filter) -> 'ObjectStream':
+    def Where(self, filter: Union[str, ast.Lambda, Callable]) -> 'ObjectStream':
         r'''
         Filter the object stream, allowing only items for which `filter` evaluates as true through.
 
@@ -85,6 +93,10 @@ class ObjectStream:
         Returns:
 
             A new ObjectStream that contains only elements that pass the filter function
+
+        Notes:
+            - The function can be a `lambda`, the name of a one-line function, a string that contains
+              a lambda definition, or a python `ast` of type `ast.Lambda`.
         '''
         return ObjectStream(function_call("Where", [self._q_ast, cast(ast.AST, parse_as_ast(filter))]))
 

--- a/func_adl/util_ast.py
+++ b/func_adl/util_ast.py
@@ -199,7 +199,7 @@ class _find_lambda(ast.NodeVisitor):
 
     def visit_Lambda(self, node: ast.Lambda) -> Any:
         if self._found is not None:
-            raise Exception(f'The line of source contained more than one lambda on it! Cannot tell which one to read!')
+            raise Exception('The line of source contained more than one lambda on it! Cannot tell which one to read!')
         self._found = node
 
 

--- a/tests/test_object_stream.py
+++ b/tests/test_object_stream.py
@@ -31,6 +31,15 @@ def test_simple_query():
     assert isinstance(r, ast.AST)
 
 
+def test_simple_query_lambda():
+    r = my_event() \
+        .SelectMany(lambda e: e.jets()) \
+        .Select(lambda j: j.pT()) \
+        .AsROOTTTree("junk.root", "analysis", "jetPT") \
+        .value()
+    assert isinstance(r, ast.AST)
+
+
 def test_simple_query_parquet():
     r = my_event() \
         .SelectMany("lambda e: e.jets()") \

--- a/tests/test_util_ast.py
+++ b/tests/test_util_ast.py
@@ -1,5 +1,5 @@
 import ast
-from typing import cast
+from typing import Callable, cast
 
 import pytest
 
@@ -155,3 +155,17 @@ def test_parse_simple_func():
 
     with pytest.raises(Exception):
         parse_as_ast(doit)
+
+
+def test_run_on_parse():
+    'Emulate the syntax you often find when you have a multistep query'
+    class my_obj:
+        def do_it(self, x: Callable):
+            parse_as_ast(x)
+            return self
+
+    # #&$&#^$^@ this parse error makes this almost not useful.
+    with pytest.raises(Exception):
+        long_expr = my_obj() \
+            .do_it(lambda x: x + 1) \
+            .do_it(lambda y: y + 2)

--- a/tests/test_util_ast.py
+++ b/tests/test_util_ast.py
@@ -1,22 +1,13 @@
-# Tests for ast_util.py
-
-# Now the real test code starts.
 import ast
 from typing import cast
 
+import pytest
+
 from func_adl.util_ast import (
-    as_ast,
-    function_call,
-    lambda_args,
-    lambda_body_replace,
-    lambda_build,
-    lambda_call,
-    lambda_is_identity,
-    lambda_is_true,
-    lambda_test,
-    lambda_unwrap,
-    parse_as_ast,
-)
+    as_ast, function_call, lambda_args, lambda_body_replace, lambda_build,
+    lambda_call, lambda_is_identity, lambda_is_true, lambda_test,
+    lambda_unwrap, parse_as_ast)
+
 
 # Ast parsing
 def test_as_ast_integer():
@@ -134,3 +125,33 @@ def test_parse_as_ast_lambda():
     l = lambda_unwrap(ast.parse("lambda x: x + 1"))
     r = parse_as_ast(l)
     assert isinstance(r, ast.Lambda)
+
+
+def test_parse_as_str():
+    r = parse_as_ast('lambda x: x + 1')
+    assert isinstance(r, ast.Lambda)
+
+
+def test_parse_as_callable_simple():
+    r = parse_as_ast(lambda x: x + 1)
+    assert isinstance(r, ast.Lambda)
+
+
+def test_parse_nested_lambda():
+    r = parse_as_ast(lambda x: (lambda y: y + 1)(x))
+    assert isinstance(r, ast.Lambda)
+
+def test_parse_two_lambdas():
+    with pytest.raises(Exception) as e:
+        (parse_as_ast(lambda x: x + 1), parse_as_ast(lambda y: y * 10))
+
+    assert 'While parsing' in str(e.value)
+
+
+def test_parse_simple_func():
+    'Fail if we get a function - one day we can do this, but not quite yet'
+    def doit(x):
+        return x + 1
+
+    with pytest.raises(Exception):
+        parse_as_ast(doit)

--- a/tests/test_util_ast.py
+++ b/tests/test_util_ast.py
@@ -183,11 +183,25 @@ def test_parse_nested_lambda():
 
 
 def test_parse_simple_func():
-    'Fail if we get a function - one day we can do this, but not quite yet'
+    'A oneline function defined at local scope'
     def doit(x):
         return x + 1
 
     f = parse_as_ast(doit)
+
+    assert isinstance(f, ast.Lambda)
+    assert len(f.args.args) == 1
+    assert isinstance(f.body, ast.BinOp)
+
+
+def global_doit(x):
+    return x + 1
+
+
+def test_parse_global_simple_func():
+    'A oneline function defined at global scope'
+
+    f = parse_as_ast(global_doit)
 
     assert isinstance(f, ast.Lambda)
     assert len(f.args.args) == 1
@@ -219,7 +233,7 @@ def test_parse_continues():
 
 
 def test_parse_continues_one_line():
-    'Emulate the syntax you often find when you have a multistep query'
+    'Make sure we do not let our confusion confuse the user - bomb correctly here'
     found = []
 
     class my_obj:


### PR DESCRIPTION
Add code to accept raw source code `lambda` in `Select` and `Where` statements.

- This relies on python's `inspect.source` library. At least in 3.7 and 3.6
- This is quite brittle. There are tests that look for problems in the way things are called.
- Exceptions with some text and source code are thrown when the `lambda` can't be determined.

The problem is that this can't do a more complex lambda function that inline the way we often see them in `func_adl`:

```python
def test_run_on_parse():
    'Emulate the syntax you often find when you have a multistep query'
    class my_obj:
        def do_it(self, x: Callable):
            parse_as_ast(x)
            return self

    # #&$&#^$^@ this parse error makes this almost not useful.
    with pytest.raises(Exception):
        long_expr = my_obj() \
            .do_it(lambda x: x + 1) \
            .do_it(lambda y: y + 2)
```

For this `inspect.getsource` returns:
```
'.do_it(lambda x: x + 1) \\\n            .do_it(lambda y: y + 2)'
```

which the ast parser totally fails at, obviously.

Really need a better way to look at where the lambda starts, exactly (is this in 3.8?).

Partial fixes #45