### PR TITLE
Make compatible with 3.8 and 3.9

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,3 @@
 [flake8]
 exclude = tests/*
 max-line-length=99
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Lint with Flake8
       if: matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
       run: |
-        flake8 --exclude=tests/* --ignore=E501
+        flake8
     - name: Test with pytest
       run: |
         python -m pytest -r sx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -97,9 +97,9 @@ celerybeat-schedule
 
 # Environments
 .env
-.venv
+.venv*
 env/
-venv/
+venv*/
 ENV/
 env.bak/
 venv.bak/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -49,7 +49,7 @@
     ],
     "pyright.openFilesOnly": false,
     "python.analysis.openFilesOnly": false,
-    "python.pythonPath": ".venv\\Scripts\\python.exe",
+    "python.pythonPath": ".venv-39\\Scripts\\python.exe",
     "python.venvPath": ".venv",
     "python.analysis.typeCheckingMode": "basic",
     "python.testing.pytestArgs": [

--- a/func_adl/ast/aggregate_shortcuts.py
+++ b/func_adl/ast/aggregate_shortcuts.py
@@ -1,4 +1,3 @@
-# We will look for various things in the AST that, in the end, translate to the Aggregate terminal. And then translate them.
 import ast
 import sys
 from func_adl.util_ast import function_call
@@ -16,7 +15,7 @@ def _generate_count_call(seq: ast.AST, lambda_string: str = "lambda acc,v: acc+1
         agg_ast - An ast call to the Aggregate call.
     '''
     agg_lambda = cast(ast.Expr, ast.parse(lambda_string).body[0]).value
-    agg_start = ast.Num(0) if sys.version_info < (3, 8, 0) else ast.Constant(0, kind = None)
+    agg_start = ast.Num(0) if sys.version_info < (3, 8, 0) else ast.Constant(0, kind=None)
 
     return function_call('Aggregate', [seq, cast(ast.AST, agg_start), cast(ast.AST, agg_lambda)])
 
@@ -37,7 +36,9 @@ class aggregate_node_transformer(ast.NodeTransformer):
             elif node.func.id == "Sum":
                 return _generate_count_call(self.visit(node.args[0]), "lambda acc,v: acc + v")
             elif node.func.id == "Max":
-                return _generate_count_call(self.visit(node.args[0]), "lambda acc,v: acc if acc > v else v")
+                return _generate_count_call(self.visit(node.args[0]),
+                                            "lambda acc,v: acc if acc > v else v")
             elif node.func.id == "Min":
-                return _generate_count_call(self.visit(node.args[0]), "lambda acc,v: acc if acc < v else v")
+                return _generate_count_call(self.visit(node.args[0]),
+                                            "lambda acc,v: acc if acc < v else v")
         return self.generic_visit(node)

--- a/func_adl/ast/aggregate_shortcuts.py
+++ b/func_adl/ast/aggregate_shortcuts.py
@@ -1,5 +1,6 @@
 # We will look for various things in the AST that, in the end, translate to the Aggregate terminal. And then translate them.
 import ast
+import sys
 from func_adl.util_ast import function_call
 from typing import cast
 
@@ -15,7 +16,7 @@ def _generate_count_call(seq: ast.AST, lambda_string: str = "lambda acc,v: acc+1
         agg_ast - An ast call to the Aggregate call.
     '''
     agg_lambda = cast(ast.Expr, ast.parse(lambda_string).body[0]).value
-    agg_start = ast.Num(0)
+    agg_start = ast.Num(0) if sys.version_info < (3, 8, 0) else ast.Constant(0, kind = None)
 
     return function_call('Aggregate', [seq, cast(ast.AST, agg_start), cast(ast.AST, agg_lambda)])
 

--- a/func_adl/ast/call_stack.py
+++ b/func_adl/ast/call_stack.py
@@ -26,7 +26,8 @@ class argument_stack:
         Return name if it is not found.
 
         name - the name we should look up. Any object that can be a key in a dict
-        default - If none, if the name can't be found, return the name. Otherwise return whatever default is.
+        default - If none, if the name can't be found, return the name. Otherwise return whatever
+        default is.
         '''
         for frames in reversed(self._arg_transformer):
             if name in frames:

--- a/func_adl/event_dataset.py
+++ b/func_adl/event_dataset.py
@@ -31,8 +31,8 @@ class EventDataset(ObjectStream, ABC):
     @abstractmethod
     async def execute_result_async(self, a: ast.AST) -> Any:
         '''
-        Override in your sub-class. The infrastructure will call this to render the result "locally", or as
-        requested by the AST.
+        Override in your sub-class. The infrastructure will call this to render the result
+        "locally", or as requested by the AST.
         '''
         pass
 

--- a/func_adl/object_stream.py
+++ b/func_adl/object_stream.py
@@ -21,11 +21,11 @@ class ObjectStream:
     of `ObjectStream` objects, linked together, is a DAG that stores the user's intent.
 
     Every stream has an _object type_. This is the type of the elements of the stream. For example,
-    the top stream, the objects are of type `Event` (or `xADOEvent`). If you transform an `Event` into
-    a list of jets, then the object type will be a list of `Jet` objects. Each element of the stream
-    is an array. You can also lift this second array of `Jets` and turn it into a plain stream
-    of `Jets` using the `SelectMany` method below. In that case, you'll no longer be able to tell
-    the boundary between events.
+    the top stream, the objects are of type `Event` (or `xADOEvent`). If you transform an `Event`
+    into a list of jets, then the object type will be a list of `Jet` objects. Each element of the
+    stream is an array. You can also lift this second array of `Jets` and turn it into a plain
+    stream of `Jets` using the `SelectMany` method below. In that case, you'll no longer be able
+    to tell the boundary between events.
     '''
     def __init__(self, the_ast: ast.AST):
         r"""
@@ -58,10 +58,11 @@ class ObjectStream:
             A new ObjectStream of the type of the elements.
 
         Notes:
-            - The function can be a `lambda`, the name of a one-line function, a string that contains
-              a lambda definition, or a python `ast` of type `ast.Lambda`.
+            - The function can be a `lambda`, the name of a one-line function, a string that
+              contains a lambda definition, or a python `ast` of type `ast.Lambda`.
         """
-        return ObjectStream(function_call("SelectMany", [self._q_ast, cast(ast.AST, parse_as_ast(func))]))
+        return ObjectStream(function_call("SelectMany",
+                                          [self._q_ast, cast(ast.AST, parse_as_ast(func))]))
 
     def Select(self, f: Union[str, ast.Lambda, Callable]) -> 'ObjectStream':
         r"""
@@ -77,8 +78,8 @@ class ObjectStream:
             A new ObjectStream of the transformed elements.
 
         Notes:
-            - The function can be a `lambda`, the name of a one-line function, a string that contains
-              a lambda definition, or a python `ast` of type `ast.Lambda`.
+            - The function can be a `lambda`, the name of a one-line function, a string that
+              contains a lambda definition, or a python `ast` of type `ast.Lambda`.
         """
         return ObjectStream(function_call("Select", [self._q_ast, cast(ast.AST, parse_as_ast(f))]))
 
@@ -95,16 +96,17 @@ class ObjectStream:
             A new ObjectStream that contains only elements that pass the filter function
 
         Notes:
-            - The function can be a `lambda`, the name of a one-line function, a string that contains
-              a lambda definition, or a python `ast` of type `ast.Lambda`.
+            - The function can be a `lambda`, the name of a one-line function, a string that
+              contains a lambda definition, or a python `ast` of type `ast.Lambda`.
         '''
-        return ObjectStream(function_call("Where", [self._q_ast, cast(ast.AST, parse_as_ast(filter))]))
+        return ObjectStream(function_call("Where",
+                                          [self._q_ast, cast(ast.AST, parse_as_ast(filter))]))
 
     def AsPandasDF(self, columns=[]) -> 'ObjectStream':
         r"""
         Return a pandas stream that contains one item, an pandas `DataFrame`.
-        This `DataFrame` will contain all the data fed to it. Only non-array datatypes are permitted:
-        the data must look like an Excel table.
+        This `DataFrame` will contain all the data fed to it. Only non-array datatypes are
+        permitted: the data must look like an Excel table.
 
         Arguments:
 
@@ -141,7 +143,10 @@ class ObjectStream:
             dataset.  The order of the files back is consistent for different queries on the same
             dataset.
         """
-        return ObjectStream(function_call("ResultTTree", [self._q_ast, as_ast(columns), as_ast(treename), as_ast(filename)]))
+        return ObjectStream(
+            function_call("ResultTTree",
+                          [self._q_ast, as_ast(columns), as_ast(treename), as_ast(filename)])
+            )
 
     def AsParquetFiles(self, filename: str, columns: Union[str, List[str]] = []) -> 'ObjectStream':
         '''Returns the sequence of items as a `parquet` file. Each item in the ObjectStream gets a separate
@@ -151,26 +156,31 @@ class ObjectStream:
             vector<float>       A tree with a list of floats in each entry will be written.
             (<tuple>)           A tree with multiple items (leaves) will be written. Each leaf
                                 must have one of the above types. Nested tuples are not supported.
-            {k:v, }             A dictionary with named columns. v is either a float or a vector of floats.
+            {k:v, }             A dictionary with named columns. v is either a float or a vector
+                                of floats.
 
         Arguments:
 
-            filename            Name of a file in which the data will be written. Depending on where the data comes
-                                from this may not be used - consider it a suggestion.
-            columns             If the data does not arrive by dictionary, then these are the column names.
+            filename            Name of a file in which the data will be written. Depending on
+                                where the data comes from this may not be used - consider it a
+                                suggestion.
+            columns             If the data does not arrive by dictionary, then these are the
+                                column names.
 
         Returns:
 
-            A new `ObjectStream` with type `[filename]`. This is because multiple files may be written by
-            the backend - the data should be concatinated together to get a final result. The order of the files back
-            is consistent for different queries on the same dataset.
+            A new `ObjectStream` with type `[filename]`. This is because multiple files may be
+            written by the backend - the data should be concatinated together to get a final
+            result. The order of the files back is consistent for different queries on the same
+            dataset.
         '''
-        return ObjectStream(function_call("ResultParquet", [self._q_ast, as_ast(columns), as_ast(filename)]))
+        return ObjectStream(function_call("ResultParquet",
+                                          [self._q_ast, as_ast(columns), as_ast(filename)]))
 
     def AsAwkwardArray(self, columns=[]) -> 'ObjectStream':
         r'''
-        Return a pandas stream that contains one item, an `awkward` array, or dictionary of `awkward` arrays.
-        This `awkward` will contain all the data fed to it.
+        Return a pandas stream that contains one item, an `awkward` array, or dictionary of
+        `awkward` arrays. This `awkward` will contain all the data fed to it.
 
         Arguments:
 
@@ -183,7 +193,8 @@ class ObjectStream:
         '''
         return ObjectStream(function_call("ResultAwkwardArray", [self._q_ast, as_ast(columns)]))
 
-    def _get_executor(self, executor: Callable[[ast.AST], Awaitable[Any]] = None) -> Callable[[ast.AST], Awaitable[Any]]:
+    def _get_executor(self, executor: Callable[[ast.AST], Awaitable[Any]] = None) \
+            -> Callable[[ast.AST], Awaitable[Any]]:
         r'''
         Returns an executor that can be used to run this.
         Logic seperated out as it is used from several different places.

--- a/func_adl/util_ast.py
+++ b/func_adl/util_ast.py
@@ -212,9 +212,11 @@ def rewrite_func_as_lambda(f: ast.FunctionDef) -> ast.Lambda:
           done of the statement or args - they are just re-used.
     '''
     if len(f.body) != 1:
-        raise ValueError(f'Can handle simple functions of only one line - "{f.name}"" has {len(f.body)}.')
+        raise ValueError(f'Can handle simple functions of only one line - "{f.name}"'
+                         f' has {len(f.body)}.')
     if not isinstance(f.body[0], ast.Return):
-        raise ValueError(f'Simple function must use return statement - "{f.name}" does not seem to.')
+        raise ValueError(f'Simple function must use return statement - "{f.name}" does '
+                         'not seem to.')
 
     # the arguments
     args = f.args
@@ -264,7 +266,8 @@ def parse_as_ast(ast_source: Union[str, ast.AST, Callable]) -> ast.Lambda:
             new_line = stem.find('\n')
             next_caller = stem.find(caller_name)
             if next_caller > -1 and (new_line < 0 or new_line > next_caller):
-                raise ValueError(f'Found two calls to {caller_name} on same line - split accross lines')
+                raise ValueError(f'Found two calls to {caller_name} on same line - '
+                                 'split accross lines')
             source = source[:i + 1]
 
         def parse(src: str) -> Optional[ast.Module]:

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,6 @@ setup(name="func_adl_test",
                    "Topic :: Utilities",
       ],
       data_files=[],
-      python_requires='>=3.6, <3.8',
+      python_requires='>=3.6, <3.10',
       platforms="Any",
       )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,10 @@ from distutils.core import setup
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-extras_require = {'test': ['pytest', 'pytest-asyncio', 'pytest-cov', 'flake8', 'coverage', 'twine', 'wheel', 'astunparse']}
+extras_require = {'test': [
+    'pytest', 'pytest-asyncio', 'pytest-cov', 'flake8', 'coverage', 'twine', 'wheel', 'astunparse'
+    ]
+}
 extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 
 setup(name="func_adl_test",

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,12 @@ from distutils.core import setup
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-extras_require = {'test': [
-    'pytest', 'pytest-asyncio', 'pytest-cov', 'flake8', 'coverage', 'twine', 'wheel', 'astunparse'
-    ]
-}
+extras_require = {
+    'test': [
+                'pytest', 'pytest-asyncio', 'pytest-cov', 'flake8',
+                'coverage', 'twine', 'wheel', 'astunparse'
+            ]
+                 }
 extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 
 setup(name="func_adl_test",

--- a/tests/ast/test_aggregate_shortcuts.py
+++ b/tests/ast/test_aggregate_shortcuts.py
@@ -1,4 +1,3 @@
-# Test the aggregate shortcuts
 from func_adl.ast.aggregate_shortcuts import aggregate_node_transformer
 from tests.util_debug_ast import normalize_ast
 import ast

--- a/tests/test_util_ast.py
+++ b/tests/test_util_ast.py
@@ -14,40 +14,50 @@ from func_adl.util_ast import (
 def test_as_ast_integer():
     if sys.version_info < (3,8):
         assert "Num(n=1)" == ast.dump(as_ast(1))
-    else:
+    elif sys.version_info < (3,9):
         assert "Constant(value=1, kind=None)" == ast.dump(as_ast(1))
+    else:
+        assert "Constant(value=1)" == ast.dump(as_ast(1))
 
 
 
-def test_as_ast_string_37():
+def test_as_ast_string():
     if sys.version_info < (3,8):
         assert "Str(s='hi there')" == ast.dump(as_ast("hi there"))
-    else:
+    elif sys.version_info < (3,9):
         assert "Constant(value='hi there', kind=None)" == ast.dump(as_ast("hi there"))
+    else:
+        assert "Constant(value='hi there')" == ast.dump(as_ast("hi there"))
 
 
-def test_as_ast_string_var_37():
+def test_as_ast_string_var():
     s = "hi there"
     if sys.version_info < (3,8):
         assert "Str(s='hi there')" == ast.dump(as_ast(s))
-    else:
+    elif sys.version_info < (3,9):
         assert "Constant(value='hi there', kind=None)" == ast.dump(as_ast(s))
+    else:
+        assert "Constant(value='hi there')" == ast.dump(as_ast(s))
 
 
-def test_as_ast_list_37():
+def test_as_ast_list():
     if sys.version_info < (3,8):
         assert "List(elts=[Str(s='one'), Str(s='two')], ctx=Load())" == ast.dump(as_ast(["one", "two"]))
-    else:
+    elif sys.version_info < (3,9):
         assert "List(elts=[Constant(value='one', kind=None), Constant(value='two', kind=None)], ctx=Load())" == ast.dump(as_ast(["one", "two"]))
+    else:
+        assert "List(elts=[Constant(value='one'), Constant(value='two')], ctx=Load())" == ast.dump(as_ast(["one", "two"]))
 
 # Fucntion Calling
-def test_function_call_simple_37():
+def test_function_call_simple():
     a = function_call('dude', [as_ast(1)])
     print (ast.dump(ast.parse('dude(1)')))
     if sys.version_info < (3,8):
         expected = "Call(func=Name(id='dude', ctx=Load()), args=[Num(n=1)], keywords=[])"
-    else:
+    elif sys.version_info < (3,9):
         expected = "Call(func=Name(id='dude', ctx=Load()), args=[Constant(value=1, kind=None)], keywords=[])"
+    else:
+        expected = "Call(func=Name(id='dude', ctx=Load()), args=[Constant(value=1)], keywords=[])"
     assert expected == ast.dump(a)
 
 
@@ -140,10 +150,12 @@ def test_lambda_replace_simple_expression():
 
     a2 = lambda_body_replace(lambda_unwrap(a1), expr)
     a2_txt = ast.dump(a2)
-    if sys.version_info <= (3, 8):
+    if sys.version_info < (3, 8):
         assert "op=Add(), right=Num(n=1))" in a2_txt
-    else:
+    elif sys.version_info < (3,9):
         assert "op=Add(), right=Constant(value=1, kind=None))" in a2_txt
+    else:
+        assert "op=Add(), right=Constant(value=1))" in a2_txt
 
 
 def test_rewrite_oneliner():


### PR DESCRIPTION
The `ast` module and how python parses code changes in some small ways moving between python versions 3.7 and 3.9. This set of changes updates this package to run in anything from 3.6 to 3.9.

All changes should be backwards compabile.

It should be noted that just because this works doesn't mean it can be used: a client running in 3.8 sending to a service running in 3.7 has not yet been tested.