### PR TITLE
Store executor in hidden attribute of AST and remove EventDataset object from args

### DIFF
--- a/func_adl/event_dataset.py
+++ b/func_adl/event_dataset.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 import ast
-from typing import Any, Optional, cast, List
+from typing import Any, Optional
 
 from .object_stream import ObjectStream, executor_attr_name
 from .util_ast import function_call

--- a/func_adl/event_dataset.py
+++ b/func_adl/event_dataset.py
@@ -17,11 +17,15 @@ class EventDataset(ObjectStream, ABC):
         Should not be called directly. Make sure to initialize this ctor
         or tracking information will be lost.
         '''
-        # We participate in the AST parsing - as a node. This argument is used in a lookup
-        # later on - so do not alter this in a subclass without understanding what is
-        # going on!
+
+        # Create the base AST node.
         ed_ast = function_call('EventDataset', [])
+
+        # Safely store a reference to our executor in the AST in an attribute not used by the
+        # the native Python ast module.
         setattr(ed_ast, executor_attr_name, self.execute_result_async)
+
+        # Let ObjectStream take care of passing around this AST.
         super().__init__(ed_ast)
 
     def __repr__(self):

--- a/func_adl/event_dataset.py
+++ b/func_adl/event_dataset.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 import ast
 from typing import Any, Optional, cast, List
 
-from .object_stream import ObjectStream
+from .object_stream import ObjectStream, executor_attr_name
 from .util_ast import function_call
 
 
@@ -20,7 +20,9 @@ class EventDataset(ObjectStream, ABC):
         # We participate in the AST parsing - as a node. This argument is used in a lookup
         # later on - so do not alter this in a subclass without understanding what is
         # going on!
-        super().__init__(function_call('EventDataset', [ast.Constant(value=self)]))
+        ed_ast = function_call('EventDataset', [])
+        setattr(ed_ast, executor_attr_name, self.execute_result_async)
+        super().__init__(ed_ast)
 
     def __repr__(self):
         return f"'{self.__class__.__name__}'"
@@ -74,21 +76,3 @@ def find_EventDataset(a: ast.AST) -> ast.Call:
         raise Exception("AST Query has no root EventDataset")
 
     return ds_f.ds
-
-
-def _extract_dataset_info(ds_call: ast.Call) -> EventDataset:
-    '''
-    Convert a found ServiceX dataset in a call.
-    '''
-    args = cast(List[ast.AST], ds_call.args)
-
-    # List should be strings
-    return ast.literal_eval(args[0])
-
-
-def find_ed_in_ast(a: ast.AST) -> EventDataset:
-    '''
-    Search the `AST` for a `ServiceXDatasetSource` node,
-    and return the `sx` dataset object.
-    '''
-    return _extract_dataset_info(find_EventDataset(a))

--- a/func_adl/object_stream.py
+++ b/func_adl/object_stream.py
@@ -211,9 +211,9 @@ class ObjectStream:
         if executor is not None:
             return executor
 
-        node = self
+        node = self._q_ast
         while not hasattr(node, executor_attr_name):
-            node = self._q_ast.args[0]
+            node = node.args[0]
 
         return getattr(node, executor_attr_name)
 

--- a/func_adl/object_stream.py
+++ b/func_adl/object_stream.py
@@ -13,6 +13,7 @@ from .util_ast import as_ast, function_call, parse_as_ast
 #         Exception.__init__(self, msg)
 
 
+# Attribute that will be used to store the executor reference
 executor_attr_name = '_func_adl_executor'
 
 
@@ -211,10 +212,14 @@ class ObjectStream:
         if executor is not None:
             return executor
 
+        # Dig into the AST until we find a node with an executor reference attached. The AST is
+        # traversed by looking recursively into the source of each ObjectStream, which is always
+        # the first argument in the ast.Call node.
         node = self._q_ast
         while not hasattr(node, executor_attr_name):
             node = node.args[0]
 
+        # Extract the executor from this reference.
         return getattr(node, executor_attr_name)
 
     async def value_async(self, executor: Callable[[ast.AST], Any] = None) -> Any:

--- a/func_adl/object_stream.py
+++ b/func_adl/object_stream.py
@@ -13,6 +13,9 @@ from .util_ast import as_ast, function_call, parse_as_ast
 #         Exception.__init__(self, msg)
 
 
+executor_attr_name = '_func_adl_executor'
+
+
 class ObjectStream:
     r'''
     The objects can be events, jets, electrons, or just floats, or arrays of floats.
@@ -208,10 +211,11 @@ class ObjectStream:
         if executor is not None:
             return executor
 
-        from .event_dataset import find_ed_in_ast
-        ed = find_ed_in_ast(self._q_ast)
+        node = self
+        while not hasattr(node, executor_attr_name):
+            node = self._q_ast.args[0]
 
-        return ed.execute_result_async
+        return getattr(node, executor_attr_name)
 
     async def value_async(self, executor: Callable[[ast.AST], Any] = None) -> Any:
         r'''

--- a/tests/test_event_dataset.py
+++ b/tests/test_event_dataset.py
@@ -4,7 +4,6 @@ from typing import Any, cast
 import pytest
 
 from func_adl import EventDataset
-from func_adl.event_dataset import find_ed_in_ast
 
 def test_cannot_create():
     with pytest.raises(Exception):
@@ -28,23 +27,6 @@ class my_event_extra_args(EventDataset):
 
 def test_can_create():
     my_event()
-
-
-def test_find_event_at_top():
-    e = my_event()
-    assert find_ed_in_ast(e.query_ast) is e
-
-
-def test_find_event_inside():
-    e = my_event()
-    add = ast.BinOp(ast.Num(5), ast.Add, e.query_ast)
-    assert find_ed_in_ast(add) is e
-
-
-def test_find_event_with_more_ast():
-    e = my_event_extra_args()
-    add = ast.BinOp(ast.Num(5), ast.Add, e.query_ast)
-    assert find_ed_in_ast(add) is e
 
 
 def test_string_rep():


### PR DESCRIPTION
Changes the underlying way information is passed around in `EventDataSet` when it is converted to a python `AST`. Instead of storing a pointer back to an object, it stores the arguments used to create it in the first place. This specifically enables scenarios like #64 for `uproot`, and will also fix up issues likely to be encountered when doing the same thing for `xAOD`. Consider this cleaning up technical debt.

Should have no outward-facing changes.

Resolves #64.
