### PR TITLE
Support Dictionaries internally in the query

### DIFF
--- a/func_adl/ast/function_simplifier.py
+++ b/func_adl/ast/function_simplifier.py
@@ -114,6 +114,7 @@ class simplify_chained_calls(FuncADLNodeTransformer):
         => Select(seq, x: g(f(x)))
         '''
         _, args = unpack_Call(parent)
+        assert args is not None
         source = args[0]
         func_f = args[1]
         assert isinstance(func_f, ast.Lambda)
@@ -134,6 +135,7 @@ class simplify_chained_calls(FuncADLNodeTransformer):
         => SelectMany(seq, x: Select(f(x), y: g(y)))
         '''
         (_, args) = unpack_Call(parent)
+        assert args is not None
         source = args[0]
         func_f = args[1]
         assert isinstance(func_f, ast.Lambda)
@@ -258,6 +260,7 @@ class simplify_chained_calls(FuncADLNodeTransformer):
         '''
         # Unpack arguments and f and g functions
         _, args = unpack_Call(parent)
+        assert args is not None
         source = args[0]
         func_f = args[1]
         assert isinstance(func_f, ast.Lambda)
@@ -277,6 +280,7 @@ class simplify_chained_calls(FuncADLNodeTransformer):
         => Select(Where(seq, x: g(f(x)), f(x))
         '''
         _, args = unpack_Call(parent)
+        assert args is not None
         source = args[0]
         func_f = args[1]
         assert isinstance(func_f, ast.Lambda)
@@ -297,6 +301,7 @@ class simplify_chained_calls(FuncADLNodeTransformer):
         => SelectMany(seq, x: Where(f(x), g(y)))
         '''
         _, args = unpack_Call(parent)
+        assert args is not None
         seq = args[0]
         func_f = args[1]
         assert isinstance(func_f, ast.Lambda)

--- a/func_adl/ast/function_simplifier.py
+++ b/func_adl/ast/function_simplifier.py
@@ -544,7 +544,7 @@ class simplify_chained_calls(FuncADLNodeTransformer):
         return ast.Attribute(value=visited_value, attr=node.attr, ctx=ast.Load())
 
 
-def _get_value_from_index(arg: Union[ast.Num, ast.Constant, ast.Index]) -> Optional[int]:
+def _get_value_from_index(arg: Union[ast.Num, ast.Constant, ast.Index, ast.Str]) -> Optional[int]:
     '''Deal with 3.6, 3.7, and 3.8 differences in how indexing for list and tuple
     subscripts is handled.
 
@@ -557,6 +557,8 @@ def _get_value_from_index(arg: Union[ast.Num, ast.Constant, ast.Index]) -> Optio
             return cast(int, a.n)
         if isinstance(a, ast.Constant):
             return a.value
+        if isinstance(a, ast.Str):
+            return a.s
         return None
 
     if isinstance(arg, ast.Index):

--- a/tests/ast/test_function_simplifier.py
+++ b/tests/ast/test_function_simplifier.py
@@ -182,3 +182,22 @@ def test_tuple_with_lambda_args_duplication_rename():
     # Note that "g" below could still be "e" and it wouldn't tickle the bug. f and e need to be different.
     util_process("Select(Select(events, lambda e: (e.eles, e.muosn)), lambda f: f[0].Select(lambda g: g.E()))",
         "Select(events, lambda e: e.eles.Select(lambda e: e.E()))")
+
+
+# Dict tests
+def test_dict_select_reference():
+    # ('n1': t1, 'n2': t2').t1 should be t1.
+    util_process('{"n1": t1, "n2": t2}.n1', 't1')
+
+
+def test_dict_select_index():
+    # ('n1': t1, 'n2': t2').t1 should be t1.
+    util_process('{"n1": t1, "n2": t2}["n1"]', 't1')
+
+
+def test_dict_in_lambda():
+    util_process('(lambda t: t.n1)({"n1": j1, "n2": j2})', 'j1')
+
+
+def test_dict_around_first():
+    util_process('Select(events, lambda e: First(Select(e.jets, lambda j: {"j": j, "e": e})).j)', 'Select(events, lambda e: First(e.jets))')

--- a/tests/ast/test_function_simplifier.py
+++ b/tests/ast/test_function_simplifier.py
@@ -110,7 +110,7 @@ def test_where_select():
 
 def test_where_first():
     util_process('Where(Select(Select(events, lambda e: First(e.jets)), lambda j: j.pt()), lambda jp: jp>40.0)', \
-        'Select(Where(events, lambda e: First(e.jets).pt() > 40.0), lambda e1: First(e1.jets).pt())')
+        'Select(Where(events, lambda e: First(Select(e.jets, lambda j: j.pt())) > 40.0), lambda e1: First(Select(e1.jets, lambda j: j.pt())))')
  
 ################
 # Testing out SelectMany


### PR DESCRIPTION
* `{'e1': t1, 'e2': t2}.e1` or `{'e1': t1, 'e2': t2}.['t1']` both evaluate to `t1`.
* A method call on the result of a `First` gets moved inside the `First` with a `Select` - this is partly because a method call very much looks like the lookup for the dictionary.

Supporting tests fixed.

This should cause no functional changes downstream, but it might mess up some of the tests in `func_adl_xAOD`.

Fixes #61 