### PR TITLE
Recover EventDataset object from complex query

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,6 +4,12 @@
     "version": "2.0.0",
     "tasks": [
         {
+            "label": "Run Code Coverage",
+            "type": "shell",
+            "command": ". .venv/scripts/activate.ps1 ; coverage-3.9.exe run -m pytest",
+            "problemMatcher": []
+        },
+        {
             "label": "Install Package",
             "type": "shell",
             "command": "${config:python.pythonPath}",

--- a/func_adl/event_dataset.py
+++ b/func_adl/event_dataset.py
@@ -25,6 +25,9 @@ class EventDataset(ObjectStream, ABC):
         # the native Python ast module.
         setattr(ed_ast, executor_attr_name, self.execute_result_async)
 
+        # Safely store a reference to this object
+        setattr(ed_ast, '_eds_object', self)
+
         # Let ObjectStream take care of passing around this AST.
         super().__init__(ed_ast)
 
@@ -40,18 +43,18 @@ class EventDataset(ObjectStream, ABC):
         Override in your sub-class. The infrastructure will call this to render the result
         "locally", or as requested by the AST.
         '''
-        pass
+        pass  # pragma: no cover
 
 
 def find_EventDataset(a: ast.AST) -> ast.Call:
     r'''
-    Given an input query ast, find the EventDataset and return it.
+    Given an input query ast, find the EventDataset `ast` and return it.
 
     Args:
         a:      An AST that represents a query
 
     Returns:
-        The `EventDataset` at the root of this query. It will not be None.
+        The `EventDataset` `ast` at the root of this query. It will not be None.
 
     Exceptions:
         If there is more than one `EventDataset` found in the query or if there
@@ -77,6 +80,6 @@ def find_EventDataset(a: ast.AST) -> ast.Call:
     ds_f.visit(a)
 
     if ds_f.ds is None:
-        raise Exception("AST Query has no root EventDataset")
+        raise Exception(f"AST Query has no root EventDataset: {ast.dump(a)}")
 
     return ds_f.ds

--- a/tests/test_event_dataset.py
+++ b/tests/test_event_dataset.py
@@ -1,8 +1,9 @@
 import ast
+from func_adl.object_stream import ObjectStream
 from typing import Any, cast
 
 import pytest
-from func_adl import EventDataset
+from func_adl import EventDataset, find_EventDataset
 
 
 def test_cannot_create():
@@ -33,3 +34,47 @@ def test_string_rep():
     e = my_event()
     assert str(e) == "my_event"
     assert repr(e) == "'my_event'"
+
+
+def test_eds_recovery():
+    'Make sure we can get back the event dataset'
+    r = my_event()
+    found_node = find_EventDataset(r.query_ast)
+    assert hasattr(found_node, '_eds_object')
+    assert found_node._eds_object == r  # type: ignore
+
+
+def test_eds_recovery_with_select():
+    r = my_event()
+    q = r.Select(lambda a: a+1)
+    found_node = find_EventDataset(q.query_ast)
+    assert found_node._eds_object == r  # type: ignore
+
+
+def test_eds_recovery_two_ds():
+    r1 = my_event()
+    r2 = my_event()
+
+    q1 = r1.Select(lambda a: a + 1)
+    q2 = r2.Select(lambda b: b + 1)
+
+    q = ObjectStream(ast.BinOp(q1.query_ast, ast.Add, q2.query_ast))
+    with pytest.raises(Exception) as e:
+        find_EventDataset(q.query_ast)
+
+    assert 'more than one' in str(e)
+
+
+def test_eds_recovery_no_root():
+    q = ObjectStream(ast.BinOp(ast.Num(1), ast.Add, ast.Num(2)))
+    with pytest.raises(Exception) as e:
+        find_EventDataset(q.query_ast)
+
+    assert 'no root' in str(e)
+
+
+def test_eds_recovery_with_odd_call():
+    r = my_event()
+    q = r.Select(lambda a: (lambda b: b + 1)(a))
+    found_node = find_EventDataset(q.query_ast)
+    assert found_node._eds_object == r  # type: ignore


### PR DESCRIPTION
* Add a reference to the event data set
* Add tests to cover finding the event data set ast node
* Add task to run code coverage easily

This will make it possible for an external library to recover the origianl EventDataset object from deep in a query hierarchy