### PR TITLE
Support Lambda Capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ met_cut = 50
 good_met = good_met_expr.value()
 ```
 
-The cut will be applied at 40, because that was the value of `met_cut` when the `Where` function was called.
+The cut will be applied at 40, because that was the value of `met_cut` when the `Where` function was called. This will also work for variables captured inside functions.
 
 ## Extensibility
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ one of the following packages:
 
 See the documentation for more information on what expressions and capabilities are possible in each of these backends.
 
+## Captured Variables
+
+Python supports closures in `lambda` values and functions. This library will resolve those closures at the point where the select method is called. For example (where `ds` is a dataset):
+
+```python
+met_cut = 40
+good_met_expr = ds.Where(lambda e: e.met > met_cut).Select(lambda e: e.met)
+met_cut = 50
+good_met = good_met_expr.value()
+```
+
+The cut will be applied at 40, because that was the value of `met_cut` when the `Where` function was called.
+
 ## Extensibility
 
 There are two several extensibility points:

--- a/func_adl/util_ast.py
+++ b/func_adl/util_ast.py
@@ -1,6 +1,7 @@
 import ast
 import inspect
-from typing import Any, Callable, List, Optional, Union, cast
+from re import A
+from typing import Any, Callable, Dict, List, Optional, Union, cast
 
 
 def as_ast(p_var: Any) -> ast.AST:
@@ -224,6 +225,17 @@ def rewrite_func_as_lambda(f: ast.FunctionDef) -> ast.Lambda:
     return ast.Lambda(args, ret.value)
 
 
+class _rewrite_captured_vars(ast.NodeTransformer):
+    def __init__(self, cv: inspect.ClosureVars):
+        self._lookup_dict: Dict[str, Any] = dict(cv.nonlocals)
+        self._lookup_dict.update(cv.globals)
+
+    def visit_Name(self, node: ast.Name) -> Any:
+        if node.id in self._lookup_dict:
+            return ast.Constant(self._lookup_dict[node.id])
+        return node
+
+
 def parse_as_ast(ast_source: Union[str, ast.AST, Callable]) -> ast.Lambda:
     r'''Return an AST for a lambda function from several sources.
 
@@ -284,15 +296,18 @@ def parse_as_ast(ast_source: Union[str, ast.AST, Callable]) -> ast.Lambda:
 
         # If this is a function, not a lambda, then we can morph and return that.
         if len(src_ast.body) == 1 and isinstance(src_ast.body[0], ast.FunctionDef):
-            return rewrite_func_as_lambda(src_ast.body[0])  # type: ignore
+            lda = rewrite_func_as_lambda(src_ast.body[0])  # type: ignore
+        else:
+            lda = next((node for node in ast.walk(src_ast)
+                    if isinstance(node, ast.Lambda)), None)
 
-        lda = next((node for node in ast.walk(src_ast)
-                   if isinstance(node, ast.Lambda)), None)
+            if lda is None:
+                raise ValueError(f'Unable to recover source for function {ast_source}.')
 
-        if lda is None:
-            raise ValueError(f'Unable to recover source for function {ast_source}.')
+        # Since this is a function in python, we can look for lambda capture.
+        call_args = inspect.getclosurevars(ast_source)
 
-        return lda
+        return _rewrite_captured_vars(call_args).visit(lda)
 
     elif isinstance(ast_source, str):
         a = ast.parse(ast_source.strip())  # type: ignore
@@ -313,6 +328,6 @@ def scan_for_metadata(a: ast.AST, callback: Callable[[ast.arg], None]):
             self.generic_visit(node)
 
             if isinstance(node.func, ast.Name) and node.func.id == 'MetaData':
-                callback(node.args[1])
+                callback(node.args[1])  # type: ignore
 
     metadata_finder().visit(a)

--- a/tests/test_util_ast.py
+++ b/tests/test_util_ast.py
@@ -241,6 +241,13 @@ def test_parse_nested_lambda():
     assert isinstance(r.body, ast.Call)
 
 
+def test_parse_lambda_capture():
+    cut_value = 30
+    r = parse_as_ast(lambda x: x > cut_value)
+    r_true = parse_as_ast(lambda x: x > 30)
+    assert ast.dump(r) == ast.dump(r_true)
+
+
 def test_parse_simple_func():
     'A oneline function defined at local scope'
     def doit(x):
@@ -265,6 +272,24 @@ def test_parse_global_simple_func():
     assert isinstance(f, ast.Lambda)
     assert len(f.args.args) == 1
     assert isinstance(f.body, ast.BinOp)
+
+
+g_val = 50
+
+
+def global_doit_capture(x):
+    return x + g_val
+
+
+def global_doit_capture_true(x):
+    return x + 50
+
+
+def test_parse_global_capture():
+    'Global function, which includes variable capture'
+    f = parse_as_ast(global_doit_capture)
+    f_true = parse_as_ast(global_doit_capture_true)
+    assert ast.dump(f) == ast.dump(f_true)
 
 
 def test_parse_continues():


### PR DESCRIPTION
* If a global variable is referenced in a lambda function, capture that in the `ast`
* If a non-local variable is referenced in a lambda function, capture that in the `ast`
* Same for a function that is inline.