### PR TITLE
Pr_query_metadata

### DIFF
--- a/func_adl/ast/meta_data.py
+++ b/func_adl/ast/meta_data.py
@@ -39,7 +39,6 @@ class _extract_metadata(FuncADLNodeTransformer):
             self._metadata.append(ast.literal_eval(node.args[1]))
             return self.visit(node.args[0])
         return super().visit_Call(node)
-        return super().visit_Call(node)
 
 
 def extract_metadata(a: ast.AST) -> Tuple[ast.AST, List[Dict[str, str]]]:

--- a/func_adl/ast/meta_data.py
+++ b/func_adl/ast/meta_data.py
@@ -1,6 +1,8 @@
 import ast
+from typing import Any, Dict, List, Optional, Tuple
+
 from func_adl.ast.func_adl_ast_utils import FuncADLNodeTransformer
-from typing import Dict, List, Tuple
+from func_adl.object_stream import ObjectStream
 
 
 class _extract_metadata(FuncADLNodeTransformer):
@@ -54,3 +56,36 @@ def extract_metadata(a: ast.AST) -> Tuple[ast.AST, List[Dict[str, str]]]:
     e = _extract_metadata()
     a_new = e.visit(a)
     return a_new, e.metadata
+
+
+def lookup_query_metadata(q: ObjectStream, metadata_name: str) -> Optional[Any]:
+    """Walk back up the query tree to find metadata_name. Return `None` if not found.
+
+    Args:
+        q (ObjectStream): Object stream to walk back up.
+        metadata_name (str): Name of the metadata item we are looking for
+
+    Returns:
+        Optional[Any]: Either the metadata value or `None`.
+    """
+
+    class _finder(ast.NodeVisitor):
+        def __init__(self):
+            self.ds: Optional[ast.Call] = None
+            self._found = None
+
+        @property
+        def found(self) -> Optional[Any]:
+            return self._found
+
+        def generic_visit(self, node: ast.AST):
+            q_metadata = getattr(node, "_q_metadata", None)
+            if q_metadata is not None:
+                if metadata_name in q_metadata:
+                    self._found = q_metadata[metadata_name]
+            return super().generic_visit(node)
+
+    ds_f = _finder()
+    ds_f.visit(q.query_ast)
+
+    return ds_f.found

--- a/func_adl/object_stream.py
+++ b/func_adl/object_stream.py
@@ -355,6 +355,8 @@ class ObjectStream(Generic[T]):
         exe = self._get_executor(executor)
 
         # Run it
-        return await exe(self._q_ast, title)
+        from func_adl.ast.meta_data import remove_empty_metadata
+
+        return await exe(remove_empty_metadata(self._q_ast), title)
 
     value = make_sync(value_async)

--- a/func_adl/object_stream.py
+++ b/func_adl/object_stream.py
@@ -214,7 +214,9 @@ class ObjectStream(Generic[T]):
             function_call("ResultPandasDF", [self._q_ast, as_ast(columns)])
         )
 
-    def AsROOTTTree(self, filename, treename, columns=[]) -> ObjectStream[ReturnedDataPlaceHolder]:
+    def AsROOTTTree(
+        self, filename: str, treename: str, columns: Union[str, List[str]] = []
+    ) -> ObjectStream[ReturnedDataPlaceHolder]:
         r"""
         Return the sequence of items as a ROOT TTree. Each item in the ObjectStream
         will get one entry in the file. The items must be of types that the infrastructure
@@ -296,7 +298,7 @@ class ObjectStream(Generic[T]):
         )
 
     def _get_executor(
-        self, executor: Callable[[ast.AST, Optional[str]], Awaitable[Any]] = None
+        self, executor: Optional[Callable[[ast.AST, Optional[str]], Awaitable[Any]]] = None
     ) -> Callable[[ast.AST, Optional[str]], Awaitable[Any]]:
         r"""
         Returns an executor that can be used to run this.
@@ -322,7 +324,9 @@ class ObjectStream(Generic[T]):
         return getattr(node, executor_attr_name)
 
     async def value_async(
-        self, executor: Callable[[ast.AST, Optional[str]], Any] = None, title: Optional[str] = None
+        self,
+        executor: Optional[Callable[[ast.AST, Optional[str]], Any]] = None,
+        title: Optional[str] = None,
     ) -> Any:
         r"""
         Evaluate the ObjectStream computation graph. Tracks back to the source dataset to

--- a/tests/ast/test_meta_data.py
+++ b/tests/ast/test_meta_data.py
@@ -2,7 +2,11 @@ import ast
 from typing import Dict, List, Optional
 
 from func_adl import EventDataset
-from func_adl.ast.meta_data import extract_metadata, lookup_query_metadata
+from func_adl.ast.meta_data import (
+    extract_metadata,
+    lookup_query_metadata,
+    remove_empty_metadata,
+)
 
 
 def compare_metadata(with_metadata: str, without_metadata: str) -> List[Dict[str, str]]:
@@ -47,7 +51,7 @@ def test_two_metadata():
 
 class my_event(EventDataset):
     async def execute_result_async(self, a: ast.AST, title: Optional[str] = None):
-        raise NotImplementedError()
+        return a
 
 
 def test_query_metadata_found():
@@ -82,3 +86,13 @@ def test_query_metadata_burried():
     )
 
     assert lookup_query_metadata(r, "three") == "forks"
+
+
+def test_remove_empty_metadata_empty():
+    r = remove_empty_metadata(my_event().MetaData({}).value())
+    assert "MetaData" not in ast.dump(r)
+
+
+def test_remove_empty_metadata_not_empty():
+    r = remove_empty_metadata(my_event().MetaData({"hi": "there"}).value())
+    assert "MetaData" in ast.dump(r)

--- a/tests/ast/test_meta_data.py
+++ b/tests/ast/test_meta_data.py
@@ -1,6 +1,8 @@
 import ast
-from func_adl.ast.meta_data import extract_metadata
-from typing import Dict, List
+from typing import Dict, List, Optional
+
+from func_adl import EventDataset
+from func_adl.ast.meta_data import extract_metadata, lookup_query_metadata
 
 
 def compare_metadata(with_metadata: str, without_metadata: str) -> List[Dict[str, str]]:
@@ -41,3 +43,42 @@ def test_two_metadata():
     assert len(meta) == 2
     assert meta[0] == {"hi": "there"}
     assert meta[1] == {"fork": "dude"}
+
+
+class my_event(EventDataset):
+    async def execute_result_async(self, a: ast.AST, title: Optional[str] = None):
+        raise NotImplementedError()
+
+
+def test_query_metadata_found():
+    r = (
+        my_event()
+        .QMetaData({"one": "two", "two": "three"})
+        .SelectMany("lambda e: e.jets()")
+        .Select("lambda j: j.pT()")
+    )
+
+    assert lookup_query_metadata(r, "one") == "two"
+
+
+def test_query_metadata_not_found():
+    r = (
+        my_event()
+        .QMetaData({"one": "two", "two": "three"})
+        .SelectMany("lambda e: e.jets()")
+        .Select("lambda j: j.pT()")
+    )
+
+    assert lookup_query_metadata(r, "three") is None
+
+
+def test_query_metadata_burried():
+    r = (
+        my_event()
+        .QMetaData({"three": "forks"})
+        .SelectMany("lambda e: e.jets()")
+        .QMetaData({"one": "two", "two": "three"})
+        .Select("lambda j: j.pT()")
+    )
+
+    assert lookup_query_metadata(r, "three") == "forks"

--- a/tests/test_object_stream.py
+++ b/tests/test_object_stream.py
@@ -156,6 +156,7 @@ def test_query_metadata():
         .value()
     )
     assert isinstance(r, ast.AST)
+    assert "MetaData" not in ast.dump(r)
 
 
 def test_query_metadata_dup(caplog):


### PR DESCRIPTION
Add the `QMetaData` extension.

* API is same as for `MetaData`
* No data is sent down to the xAOD backend
* Lookup can be performed on the query to find values
* Warnings issued if there is an attempt to override various things already set.