### PR TITLE
Bug Fix: argument names should override captured variables

### DIFF
--- a/func_adl/util_ast.py
+++ b/func_adl/util_ast.py
@@ -322,13 +322,27 @@ class _rewrite_captured_vars(ast.NodeTransformer):
     def __init__(self, cv: inspect.ClosureVars):
         self._lookup_dict: Dict[str, Any] = dict(cv.nonlocals)
         self._lookup_dict.update(cv.globals)
+        self._ignore_stack = []
 
     def visit_Name(self, node: ast.Name) -> Any:
+        if self.is_arg(node.id):
+            return node
+
         if node.id in self._lookup_dict:
             v = self._lookup_dict[node.id]
             if not callable(v):
                 return as_literal(self._lookup_dict[node.id])
         return node
+
+    def visit_Lambda(self, node: ast.Lambda) -> Any:
+        self._ignore_stack.append([a.arg for a in node.args.args])
+        v = super().generic_visit(node)
+        self._ignore_stack.pop()
+        return v
+
+    def is_arg(self, a_name: str) -> bool:
+        "If the arg is on the stack, then return true"
+        return any([a == a_name for frames in self._ignore_stack for a in frames])
 
 
 def global_getclosurevars(f: Callable) -> inspect.ClosureVars:

--- a/tests/test_util_ast.py
+++ b/tests/test_util_ast.py
@@ -279,7 +279,21 @@ def test_parse_lambda_capture():
     assert ast.dump(r) == ast.dump(r_true)
 
 
+def test_parse_lambda_capture_ignore_local():
+    x = 30  # NOQA type: ignore
+    r = parse_as_ast(lambda x: x > 20)
+    r_true = parse_as_ast(lambda y: y > 20)
+    assert ast.dump(r) == ast.dump(r_true).replace("'y'", "'x'")
+
+
 g_cut_value = 30
+
+
+def test_parse_lambda_capture_ignore_global():
+    x = 30  # NOQA type: ignore
+    r = parse_as_ast(lambda g_cut_value: g_cut_value > 20)
+    r_true = parse_as_ast(lambda y: y > 20)
+    assert ast.dump(r) == ast.dump(r_true).replace("'y'", "'g_cut_value'")
 
 
 def test_parse_lambda_capture_nested_global():


### PR DESCRIPTION
* Fixes a bug that is part of captured variables logic
* If `jets` was used as both a lambda argument an a global constant, then it would be replaced by its value in the AST

Fixes #95