### PR TITLE
Pr_nested_function_names

### DIFF
--- a/func_adl/util_ast.py
+++ b/func_adl/util_ast.py
@@ -714,7 +714,7 @@ def parse_as_ast(
         # If we have more than one lambda, there are some tricks we can try - like
         # argument names, to see if they are different.
         src_ast: Optional[ast.Lambda] = None
-        if len(found_lambdas) > 1:
+        if len(parsed_lambdas) > 1:
             caller_arg_list = inspect.getfullargspec(ast_source).args
             for idx, p_lambda in enumerate(parsed_lambdas):
                 lambda_args = [a.arg for a in p_lambda.args.args]  # type: ignore
@@ -726,7 +726,7 @@ def parse_as_ast(
                         )
                     src_ast = p_lambda
         else:
-            assert len(found_lambdas) == 1
+            assert len(parsed_lambdas) == 1, "Internal error - no lambdas found"
             src_ast = parsed_lambdas[0]
 
         if not src_ast:

--- a/tests/test_util_ast.py
+++ b/tests/test_util_ast.py
@@ -676,6 +676,7 @@ def test_parse_black_split_lambda_funny():
     # fmt: on
 
     assert len(found) == 1
+    assert "AntiKt4EMTopoJets" in ast.dump(found[0])
 
 
 def test_parse_metadata_there():

--- a/tests/test_util_ast.py
+++ b/tests/test_util_ast.py
@@ -655,6 +655,29 @@ def test_parse_multiline_lambda_with_funny_split():
     assert "Add()" not in ast.dump(found[1])
 
 
+def test_parse_black_split_lambda_funny():
+    "Seen in wild - formatting really did a number here"
+
+    found = []
+
+    class my_obj:
+        def do_it(self, x: Callable):
+            found.append(parse_as_ast(x))
+            return self
+
+    # fmt: off
+    my_obj().do_it(
+        lambda e: e.Jets("AntiKt4EMTopoJets").do_it(
+            lambda j: j.Jets("AntiKt4EMTopoJets").do_it(
+                lambda j1: j1.pt() / 1000.0
+            )
+        )
+    )
+    # fmt: on
+
+    assert len(found) == 1
+
+
 def test_parse_metadata_there():
     recoreded = None
 


### PR DESCRIPTION
Minor update to parse another case often created by black

* Split lambda from first line, but invoke again with the calling function
* Improve two checks for lack of lambda's - and add error message to failed assert.

Fixes #108
