### PR TITLE
Do not alter runtime types

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     url="https://github.com/iris-hep/func_adl",
     license="MIT",
     test_suite="tests",
-    install_requires=["make-it-sync"],
+    install_requires=["make-it-sync", "typeguard"],
     setup_requires=["pytest-runner"],
     tests_require=["pytest>=3.9"],
     extras_require=extras_require,

--- a/tests/test_util_types.py
+++ b/tests/test_util_types.py
@@ -106,6 +106,19 @@ def test_get_inherited_two_levels():
     assert get_inherited(myc) == bogus[Iterable[int]]
 
 
+def test_get_inherited_generic_twice():
+    T = TypeVar("T")
+
+    class bogus(Iterable[T]):
+        pass
+
+    myc = bogus[int]
+    assert get_inherited(myc) == Iterable[int]
+
+    myd = bogus[float]
+    assert get_inherited(myd) == Iterable[float]
+
+
 def test_build_type_int():
     assert build_type_dict_from_type(int) == {}
 

--- a/tests/test_util_types.py
+++ b/tests/test_util_types.py
@@ -1,6 +1,7 @@
 from typing import Any, Generic, Iterable, TypeVar
 
 import pytest
+from typeguard import check_type
 
 from func_adl.util_types import (
     _resolve_type,
@@ -89,7 +90,7 @@ def test_get_inherited_generic():
 
     myc = bogus[int]
 
-    assert get_inherited(myc) == Iterable[int]
+    assert check_type(get_inherited(myc), Iterable[int])
 
 
 def test_get_inherited_two_levels():
@@ -113,10 +114,10 @@ def test_get_inherited_generic_twice():
         pass
 
     myc = bogus[int]
-    assert get_inherited(myc) == Iterable[int]
+    assert check_type(get_inherited(myc), Iterable[int])
 
     myd = bogus[float]
-    assert get_inherited(myd) == Iterable[float]
+    assert check_type(get_inherited(myd), Iterable[float])
 
 
 def test_build_type_int():


### PR DESCRIPTION
Fixes #118 - Do not alter python runtime types on the fly

* Move ot using typeguard for more complete type checking and comparison
* Correctly create new parameterized types rather than modifying them in place.