### PR TITLE
Allow object stream operations to retain original subclass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,5 @@ dmypy.json
 # Pyre type checker
 .pyre/
 *.whl
+
+.idea/

--- a/func_adl/object_stream.py
+++ b/func_adl/object_stream.py
@@ -248,6 +248,8 @@ class ObjectStream(Generic[T]):
             function_call("ResultPandasDF", [self._q_ast, as_ast(columns)])
         )
 
+    as_pandas = AsPandasDF
+
     def AsROOTTTree(
         self, filename: str, treename: str, columns: Union[str, List[str]] = []
     ) -> ObjectStream[ReturnedDataPlaceHolder]:

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ if version is None:
     import logging
 
     logging.error("func_adl_version environment variable not set")
-    version = "0.0.1a1"
+    version = "3.2"
 version = version.split("/")[-1]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ if version is None:
     import logging
 
     logging.error("func_adl_version environment variable not set")
-    version = "3.2"
+    version = "0.0.1a1"
 version = version.split("/")[-1]
 
 setup(


### PR DESCRIPTION
# Problem
Each of the ObjectStream operations (Select, Where, etc) create a new ObjectStream instance. If a developer has subclassed ObjectStream and stored values in the instance variables, this information is lost at each step in the chain of operations.

We need a way to preserve the original subclass and instance as we construct the AST.

# Approach
Instead of returning a new instance of ObjectStream use a `deepcopy` of input object at each step.