### PR TITLE
Do not add an empty MetaData call

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,8 @@ on:
   pull_request:
   # Run daily at 0:01 UTC
   schedule:
-    - cron: "1 0 * * *"
+    # cron string to run once a week
+    - cron: "30 1 1,15 * *"
 
 jobs:
   flake8:


### PR DESCRIPTION
* Empty MetaData calls are illegal - and cause a backend crash
* The QMetaData, if called first, can generate an empty metadata call
* Prevent this by properly creating a new empty `ast`