### PR TITLE
Imported module names/function should be correctly passed to qastle.

### DIFF
--- a/func_adl/util_ast.py
+++ b/func_adl/util_ast.py
@@ -341,7 +341,8 @@ class _rewrite_captured_vars(ast.NodeTransformer):
                     if type(v) not in legal_capture_types:
                         raise ValueError(
                             f"Do not know how to capture data type '{type(v).__name__}' for "
-                            f"variable '{node.id}' - only {', '.join([c.__name__ for c in legal_capture_types])} are "
+                            f"variable '{node.id}' - only "
+                            f"{', '.join([c.__name__ for c in legal_capture_types])} are "
                             "supported."
                         )
                     return as_literal(v)

--- a/func_adl/util_ast.py
+++ b/func_adl/util_ast.py
@@ -5,6 +5,7 @@ import inspect
 import sys
 import tokenize
 from collections import defaultdict
+from types import ModuleType
 from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union, cast
 
 # Some functions to enable backwards compatibility.
@@ -333,7 +334,10 @@ class _rewrite_captured_vars(ast.NodeTransformer):
         if node.id in self._lookup_dict:
             v = self._lookup_dict[node.id]
             if not callable(v):
-                return as_literal(self._lookup_dict[node.id])
+                # Modules should be sent on down to be dealt with by the
+                # backend.
+                if not isinstance(v, ModuleType):
+                    return as_literal(v)
         return node
 
     def visit_Lambda(self, node: ast.Lambda) -> Any:

--- a/func_adl/util_ast.py
+++ b/func_adl/util_ast.py
@@ -337,6 +337,13 @@ class _rewrite_captured_vars(ast.NodeTransformer):
                 # Modules should be sent on down to be dealt with by the
                 # backend.
                 if not isinstance(v, ModuleType):
+                    legal_capture_types = [str, int, float, bool, complex, str, bytes]
+                    if type(v) not in legal_capture_types:
+                        raise ValueError(
+                            f"Do not know how to capture data type '{type(v).__name__}' for "
+                            f"variable '{node.id}' - only {', '.join([c.__name__ for c in legal_capture_types])} are "
+                            "supported."
+                        )
                     return as_literal(v)
         return node
 

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ extras_require = {
         "astunparse",
         "black",
         "isort",
+        "numpy",
     ]
 }
 extras_require["complete"] = sorted(set(sum(extras_require.values(), [])))

--- a/tests/test_object_stream.py
+++ b/tests/test_object_stream.py
@@ -343,15 +343,22 @@ def test_query_with_comprehensions():
 
 
 def test_non_imported_function_call():
-    r = my_event().Select(lambda event: np.cos(event.MET_phi)).value()  # NOQA
+    r = (
+        my_event()
+        .Select(lambda event: np.cos(event.MET_phi))  # type: ignore # noqa
+        .Where(lambda p: p > 0.0)
+        .value()
+    )  # NOQA
     assert isinstance(r, ast.AST)
+    assert "Attribute(value=Name(id='np', ctx=Load()), attr='cos', ctx=Load())" in ast.dump(r)
 
 
 def test_imported_function_call():
     import numpy as np
 
-    r = my_event().Select(lambda event: np.cos(event.MET_phi)).value()
+    r = my_event().Select(lambda event: np.cos(event.MET_phi)).Where(lambda p: p > 0.0).value()
     assert isinstance(r, ast.AST)
+    assert "Attribute(value=Name(id='np', ctx=Load()), attr='cos', ctx=Load())" in ast.dump(r)
 
 
 def test_bad_where():

--- a/tests/test_object_stream.py
+++ b/tests/test_object_stream.py
@@ -35,9 +35,7 @@ class dd_jet:
 T = TypeVar("T")
 
 
-def add_md_for_type(
-    s: ObjectStream[T], a: ast.Call
-) -> Tuple[ObjectStream[T], ast.Call]:
+def add_md_for_type(s: ObjectStream[T], a: ast.Call) -> Tuple[ObjectStream[T], ast.Call]:
     return s.MetaData({"hi": "there"}), a
 
 
@@ -323,9 +321,7 @@ def test_query_metadata_not_empty():
 def test_nested_query_rendered_correctly():
     r = (
         my_event()
-        .Where(
-            "lambda e: e.jets.Select(lambda j: j.pT()).Where(lambda j: j > 10).Count() > 0"
-        )
+        .Where("lambda e: e.jets.Select(lambda j: j.pT()).Where(lambda j: j > 10).Count() > 0")
         .SelectMany("lambda e: e.jets()")
         .AsROOTTTree("junk.root", "analysis", "jetPT")
         .value()
@@ -344,6 +340,18 @@ def test_query_with_comprehensions():
     )
     assert isinstance(r, ast.AST)
     assert "ListComp" not in ast.dump(r)
+
+
+def test_non_imported_function_call():
+    r = my_event().Select(lambda event: np.cos(event.MET_phi)).value()  # NOQA
+    assert isinstance(r, ast.AST)
+
+
+def test_imported_function_call():
+    import numpy as np
+
+    r = my_event().Select(lambda event: np.cos(event.MET_phi)).value()
+    assert isinstance(r, ast.AST)
 
 
 def test_bad_where():

--- a/tests/test_util_ast.py
+++ b/tests/test_util_ast.py
@@ -309,6 +309,19 @@ def test_parse_lambda_capture_nested_local():
     assert ast.dump(r) == ast.dump(r_true)
 
 
+def test_sensible_error_with_bad_variable_capture():
+    class bogus:
+        def __init__(self):
+            self.my_var = 10
+
+    my_var = bogus()
+
+    with pytest.raises(ValueError) as e:
+        parse_as_ast(lambda x: x > my_var)
+
+    assert "my_var" in str(e)
+
+
 def test_parse_simple_func():
     "A oneline function defined at local scope"
 


### PR DESCRIPTION
Passing through `np` and other module names for some functions didn't work if `np` had already been imported into the namespace. This fixes that and improves error messages around non-standard lambda captures.

* `ModuleType` is now "captured" as just the name you use. So `np` and `numpy` are both passed down (warning!). `np` should no work both if or if it hasn't been imported.
* White list for types of things that can be sent down: `str, int, float, bool, complex, str,` and `bytes`.
* Added `numpy` to test install flavor so this functionality could be tested. 

Fixes #127