### PR TITLE
build: Support Python 3.7+

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,5 @@
 [flake8]
 max-line-length=99
 ignore=E203, W503
+per-file-ignores =
+    setup.py:E501

--- a/func_adl/ast/function_simplifier.py
+++ b/func_adl/ast/function_simplifier.py
@@ -439,7 +439,7 @@ class simplify_chained_calls(FuncADLNodeTransformer):
 
         Only works if index is a number
         """
-        # Get the value out - this is due to supporting python 3.6-3.9
+        # Get the value out - this is due to supporting python 3.7-3.9
         n = _get_value_from_index(s)
         if n is None:
             return ast.Subscript(v, s, ast.Load())
@@ -564,7 +564,7 @@ class simplify_chained_calls(FuncADLNodeTransformer):
 
 
 def _get_value_from_index(arg: Union[ast.Num, ast.Constant, ast.Index, ast.Str]) -> Optional[int]:
-    """Deal with 3.6, 3.7, and 3.8 differences in how indexing for list and tuple
+    """Deal with 3.7, and 3.8 differences in how indexing for list and tuple
     subscripts is handled.
 
     Args:

--- a/func_adl/type_based_replacement.py
+++ b/func_adl/type_based_replacement.py
@@ -158,7 +158,7 @@ def _find_keyword(
 
 
 # Some functions to enable backwards compatibility.
-# Capability may be degraded in older versions - particularly 3.6.
+# Capability may be degraded in older versions.
 if sys.version_info >= (3, 8):  # pragma: no cover
 
     def get_type_args(tp):

--- a/func_adl/util_ast.py
+++ b/func_adl/util_ast.py
@@ -9,7 +9,7 @@ from types import ModuleType
 from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union, cast
 
 # Some functions to enable backwards compatibility.
-# Capability may be degraded in older versions - particularly 3.6.
+# Capability may be degraded in older versions.
 if sys.version_info >= (3, 8):  # pragma: no cover
 
     def as_literal(p: Union[str, int, float, bool, None]) -> ast.Constant:

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,33 @@
-# Need setuptools even though it isn't used - loads some plugins.
 import os
-from distutils.core import setup
+import sys
 
-from setuptools import find_packages  # noqa: F401
+from setuptools import find_packages, setup  # noqa: F401
+
+
+# Taken from Numba
+def _guard_python_version(max_python):
+    version_module = None
+    try:
+        from packaging import version as version_module
+    except ImportError:
+        try:
+            from setuptools._vendor.packaging import version as version_module
+        except ImportError:
+            pass
+
+    if version_module is None:
+        return
+
+    current_python = version_module.parse(".".join(map(str, sys.version_info[:3])))
+    max_python = version_module.parse(max_python)
+
+    if not current_python < max_python:
+        raise RuntimeError(
+            f"Cannot install on Python version {current_python} as Python {max_python}+ is not yet supported."
+        )
+
+
+_guard_python_version(max_python="3.13")
 
 # Use the readme as the long description.
 with open("README.md", "r") as fh:
@@ -67,12 +92,11 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Topic :: Software Development",
         "Topic :: Utilities",
     ],
     data_files=[],
-    python_requires=">=3.6, <3.13",
+    python_requires=">=3.7",
     platforms="Any",
 )


### PR DESCRIPTION
Resolves #101

* For the requires-python metadata, require Python 3.7+ as all CPython versions up through Python 3.7 are now EOL. Python 3.7 support should also be dropped, but that can be done incrementally.

```
┌───────┬────────────┬─────────┬────────────────┬────────────┬────────────┐
│ cycle │  release   │ latest  │ latest release │  support   │    eol     │
├───────┼────────────┼─────────┼────────────────┼────────────┼────────────┤
│ 3.12  │ 2023-10-02 │ 3.12.2  │   2024-02-06   │ 2025-04-02 │ 2028-10-31 │
│ 3.11  │ 2022-10-24 │ 3.11.8  │   2024-02-06   │ 2024-04-01 │ 2027-10-31 │
│ 3.10  │ 2021-10-04 │ 3.10.13 │   2023-08-24   │ 2023-04-05 │ 2026-10-31 │
│ 3.9   │ 2020-10-05 │ 3.9.18  │   2023-08-24   │ 2022-05-17 │ 2025-10-31 │
│ 3.8   │ 2019-10-14 │ 3.8.18  │   2023-08-24   │ 2021-05-03 │ 2024-10-31 │
│ 3.7   │ 2018-06-26 │ 3.7.17  │   2023-06-05   │ 2020-06-27 │ 2023-06-27 │
│ 3.6   │ 2016-12-22 │ 3.6.15  │   2021-09-03   │ 2018-12-24 │ 2021-12-23 │
│ 3.5   │ 2015-09-12 │ 3.5.10  │   2020-09-05   │   False    │ 2020-09-30 │
│ 3.4   │ 2014-03-15 │ 3.4.10  │   2019-03-18   │   False    │ 2019-03-18 │
│ 3.3   │ 2012-09-29 │ 3.3.7   │   2017-09-19   │   False    │ 2017-09-29 │
│ 3.2   │ 2011-02-20 │ 3.2.6   │   2014-10-12   │   False    │ 2016-02-20 │
│ 3.1   │ 2009-06-26 │ 3.1.5   │   2012-04-06   │   False    │ 2012-04-09 │
│ 3.0   │ 2008-12-03 │ 3.0.1   │   2009-02-12   │   False    │ 2009-06-27 │
│ 2.7   │ 2010-07-03 │ 2.7.18  │   2020-04-19   │   False    │ 2020-01-01 │
│ 2.6   │ 2008-10-01 │ 2.6.9   │   2013-10-29   │   False    │ 2013-10-29 │
└───────┴────────────┴─────────┴────────────────┴────────────┴────────────┘
```

* Remove the version cap on requires-python, as this goes against the intended metadata use.
   - c.f. https://iscinumpy.dev/post/bound-version-constraints/

* Add max supported CPython version guard in setup.py, following how Numba does a similar approach. This was recommended by Henry Schreiner as an alternative to placing a version cap on the requires-python metadata.

* In CPython 3.10 distutils was formally marked as deprecated and scheduled for removal from CPython in 3.12. Deprecate use of distutils in favor of using setuptools.
   - c.f. https://setuptools.pypa.io/en/latest/deprecated/distutils-legacy.html

* Remove Python 3.6 mentions from source code comments.