### PR TITLE
Deep-Type Dictionaries

### DIFF
--- a/func_adl/type_based_replacement.py
+++ b/func_adl/type_based_replacement.py
@@ -934,6 +934,7 @@ def remap_by_types(
             dict_dataclass = make_dataclass("dict_dataclass", fields)
 
             self._found_types[t_node] = dict_dataclass
+            return t_node
 
         def visit_Constant(self, node: ast.Constant) -> Any:
             self._found_types[node] = type(node.value)

--- a/func_adl/type_based_replacement.py
+++ b/func_adl/type_based_replacement.py
@@ -927,7 +927,10 @@ def remap_by_types(
             t_node = self.generic_visit(node)
             assert isinstance(t_node, ast.Dict)
 
-            fields: List[Tuple[str, type]] = [(ast.literal_eval(f), self.lookup_type(v)) for f, v in zip(t_node.keys, t_node.values)]  # type: ignore
+            fields: List[Tuple[str, type]] = [
+                (ast.literal_eval(f), self.lookup_type(v))  # type: ignore
+                for f, v in zip(t_node.keys, t_node.values)
+            ]
             dict_dataclass = make_dataclass("dict_dataclass", fields)
 
             self._found_types[t_node] = dict_dataclass

--- a/func_adl/type_based_replacement.py
+++ b/func_adl/type_based_replacement.py
@@ -5,7 +5,7 @@ import copy
 import inspect
 import logging
 import sys
-from dataclasses import dataclass, make_dataclass
+from dataclasses import dataclass, is_dataclass, make_dataclass
 from typing import (
     Any,
     Callable,
@@ -971,6 +971,11 @@ def remap_by_types(
                     raise ValueError(f"Key {key} not found in dict expression!!")
                 value = t_node.value.values[key_index[0]]
                 self._found_types[node] = self.lookup_type(value)
+            elif ((dc := self.lookup_type(t_node.value)) is not None) and is_dataclass(dc):
+                dc_types = get_type_hints(dc)
+                if node.attr not in dc_types:
+                    raise ValueError(f"Key {node.attr} not found in dataclass/dictionary {dc}")
+                self._found_types[node] = dc_types[node.attr]
             return t_node
 
     tt = type_transformer(o_stream)

--- a/tests/test_type_based_replacement.py
+++ b/tests/test_type_based_replacement.py
@@ -564,6 +564,20 @@ def test_dictionary_through_Select():
     assert j_info.annotation == float
 
 
+def test_dictionary_through_Select_reference():
+    """Make sure the Select statement carries the typing all the way through,
+    including a later reference"""
+
+    s = ast_lambda(
+        "e.Jets().Select(lambda j: {'pt': j.pt(), 'eta': j.eta()}).Select(lambda info: info.pt)"
+    )
+    objs = ObjectStream[Event](ast.Name(id="e", ctx=ast.Load()))
+
+    _, _, expr_type = remap_by_types(objs, "e", Event, s)
+
+    assert expr_type == Iterable[float]
+
+
 def test_indexed_tuple():
     "Check that we can type-follow through tuples"
 

--- a/tests/test_type_based_replacement.py
+++ b/tests/test_type_based_replacement.py
@@ -545,8 +545,13 @@ def test_dictionary_bad_key():
     assert "jetsss" in str(e)
 
 
+def test_dictionary_through_Select():
+    """Make sure the Select statement carries the typing all the way through"""
+    assert False
+
+
 def test_indexed_tuple():
-    "Check that we can type-follow through dictionaries"
+    "Check that we can type-follow through tuples"
 
     s = ast_lambda("(e.Jets(),)[0].Select(lambda j: j.pt())")
     objs = ObjectStream[Event](ast.Name(id="e", ctx=ast.Load()))


### PR DESCRIPTION
* Created dictionaries are assigned to a data-class
* Data class is correctly typed
* Data class is de-referenced as needed.

This is only done during type resolution. The hope is this will not affect any other part of the work flow.

Help working towards [idap 200](https://github.com/iris-hep/idap-200gbps-atlas/issues/47) test.