### PR TITLE
Test that triggers the `len` error

### DIFF
--- a/func_adl/type_based_replacement.py
+++ b/func_adl/type_based_replacement.py
@@ -61,8 +61,10 @@ def _load_default_global_functions():
     # TODO: Add in other functions
 
     def my_abs(x: float) -> float: ...  # noqa
+    def my_len(x: Iterable) -> int: ...  # noqa
 
     _global_functions["abs"] = _FuncAdlFunction("abs", my_abs, None)
+    _global_functions["len"] = _FuncAdlFunction("len", my_len, None)
 
 
 _load_default_global_functions()

--- a/tests/test_type_based_replacement.py
+++ b/tests/test_type_based_replacement.py
@@ -341,6 +341,17 @@ def test_collection_First(caplog):
     assert len(caplog.text) == 0
 
 
+def test_collection_len(caplog):
+    "Make sure `len` is properly typed"
+    s = ast_lambda("len(e.Jets('default'))")
+    objs = ObjectStream[Event](ast.Name(id="e", ctx=ast.Load()))
+
+    new_objs, new_s, expr_type = remap_by_types(objs, "e", Event, s)
+
+    assert expr_type == int
+    assert len(caplog.text) == 0
+
+
 def test_collection_Custom_Method_int(caplog):
     "A custom collection method not pre-given"
     caplog.set_level(logging.WARNING)


### PR DESCRIPTION
* Added `len` as an "internal" function, much the way `abs` is already added.
* Added small test to make sure this fixes the warning we've been seeing.

Fixes #146
