### PR TITLE
build: Support Python 3.9+ 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.8
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: "3.9"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.9
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel

--- a/func_adl/type_based_replacement.py
+++ b/func_adl/type_based_replacement.py
@@ -895,16 +895,13 @@ def remap_by_types(
             t_node = self.generic_visit(node)
             assert isinstance(t_node, ast.Subscript)
             if isinstance(t_node.value, ast.Tuple):
-                slice = t_node.slice
-                # This if statement can be removed when we no longer support 3.8.
-                if isinstance(slice, ast.Index):
-                    slice = slice.value  # type: ignore
+                _slice = t_node.slice
                 if not isinstance(slice, ast.Constant):
                     raise ValueError(
-                        f"Slices must be indexable constants only - {ast.dump(slice)} is not "
+                        f"Slices must be indexable constants only - {ast.dump(_slice)} is not "
                         "valid."
                     )
-                index = slice.value
+                index = _slice.value
                 if len(t_node.value.elts) <= index:
                     raise ValueError(f"Index {index} out of range for {ast.dump(node.value)}")
                 self._found_types[node] = self.lookup_type(t_node.value.elts[index])

--- a/func_adl/type_based_replacement.py
+++ b/func_adl/type_based_replacement.py
@@ -896,7 +896,7 @@ def remap_by_types(
             assert isinstance(t_node, ast.Subscript)
             if isinstance(t_node.value, ast.Tuple):
                 _slice = t_node.slice
-                if not isinstance(slice, ast.Constant):
+                if not isinstance(_slice, ast.Constant):
                     raise ValueError(
                         f"Slices must be indexable constants only - {ast.dump(_slice)} is not "
                         "valid."

--- a/func_adl/util_types.py
+++ b/func_adl/util_types.py
@@ -1,19 +1,7 @@
 import inspect
-import sys
 import typing
 from typing import Any, Dict, Optional, Tuple, Type, TypeVar
-
-if sys.version_info >= (3, 8):
-    from typing import get_args, get_origin
-else:  # pragma: no cover
-    # TODO: Remove this when we drop support for 3.7
-    def get_args(tp):
-        "Return arguments - this is done very simply and will fail ugly"
-        return getattr(tp, "__args__", ())
-
-    def get_origin(tp):
-        "Return the origin - this is done very simply and will fail ugly"
-        return getattr(tp, "__origin__", None)
+from typing import get_args, get_origin
 
 
 def is_iterable(t: Type) -> bool:

--- a/setup.py
+++ b/setup.py
@@ -91,12 +91,10 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.7",
         "Topic :: Software Development",
         "Topic :: Utilities",
     ],
     data_files=[],
-    python_requires=">=3.7",
+    python_requires=">=3.9",
     platforms="Any",
 )


### PR DESCRIPTION
* Resolves #158 
* Resolves #163

## Description

* Require Python 3.9+, dropping support for Python 3.7 and 3.8 as both are EOL, and Python 3.8+ syntax is already being used in the current release which already EOLs 3.7.
* Update minimum Python used in CI to 3.9.

There are stil Python 3.7 specific notes in the code:

```console
$ git grep "3\.7"
func_adl/ast/function_simplifier.py:442:        # Get the value out - this is due to supporting python 3.7-3.9
func_adl/ast/function_simplifier.py:567:    """Deal with 3.7, and 3.8 differences in how indexing for list and tuple
func_adl/type_based_replacement.py:946:            "3.7 compatibility"
func_adl/type_based_replacement.py:951:            "3.7 compatibility"
func_adl/type_based_replacement.py:956:            "3.7 compatibility"
func_adl/util_types.py:25:    * This works for 3.7 forward (but not back!)
```

but I don't know enough about func-adl internals to be able to edit these quickly, so I'll need @gordonwatts or @masonproffitt to look at that.