### PR TITLE
Remove legacy ast support (pre 3.9)

### DIFF
--- a/func_adl/ast/func_adl_ast_utils.py
+++ b/func_adl/ast/func_adl_ast_utils.py
@@ -1,5 +1,5 @@
 import ast
-from typing import Any, List, Optional, Tuple, cast
+from typing import Any, List, Optional, Tuple
 
 from func_adl.util_ast import function_call
 

--- a/func_adl/ast/func_adl_ast_utils.py
+++ b/func_adl/ast/func_adl_ast_utils.py
@@ -1,6 +1,7 @@
 import ast
+from typing import Any, List, Optional, Tuple, cast
+
 from func_adl.util_ast import function_call
-from typing import Tuple, List, Optional, cast, Any
 
 
 def is_call_of(node: ast.AST, func_name: str) -> bool:
@@ -15,7 +16,7 @@ def is_call_of(node: ast.AST, func_name: str) -> bool:
     return node.func.id == func_name
 
 
-def unpack_Call(node: ast.Call) -> Tuple[Optional[str], Optional[List[ast.AST]]]:
+def unpack_Call(node: ast.Call) -> Tuple[Optional[str], Optional[List[ast.expr]]]:
     """
     Unpack the contents of a call ast.
 
@@ -30,8 +31,7 @@ def unpack_Call(node: ast.Call) -> Tuple[Optional[str], Optional[List[ast.AST]]]
     if not isinstance(node.func, ast.Name):
         return (None, None)
 
-    args = cast(List[ast.AST], node.args)  # type: List[ast.AST]
-    return (node.func.id, args)
+    return (node.func.id, node.args)
 
 
 class FuncADLNodeTransformer(ast.NodeTransformer):
@@ -116,8 +116,6 @@ def change_extension_functions_to_calls(
                 return node
             if node.func.attr not in function_names:
                 return node
-            return function_call(
-                node.func.attr, cast(List[ast.AST], [node.func.value] + node.args)
-            )
+            return function_call(node.func.attr, [node.func.value] + node.args)
 
     return transform_calls().visit(a)

--- a/func_adl/ast/function_simplifier.py
+++ b/func_adl/ast/function_simplifier.py
@@ -1,7 +1,7 @@
 # Various node visitors to clean up nested function calls of various types.
 import ast
 import copy
-from typing import List, Optional, Tuple, Union, cast
+from typing import List, Tuple, Union, cast
 
 from func_adl.ast.call_stack import argument_stack, stack_frame
 from func_adl.ast.func_adl_ast_utils import (

--- a/func_adl/ast/function_simplifier.py
+++ b/func_adl/ast/function_simplifier.py
@@ -480,7 +480,7 @@ class simplify_chained_calls(FuncADLNodeTransformer):
     def visit_Subscript_Dict_with_value(self, v: ast.Dict, s: Union[str, int]):
         "Do the lookup for the dict"
         for index, value in enumerate(v.keys):
-            assert isinstance(value, (ast.Str, ast.Constant))
+            assert isinstance(value, ast.Constant)
             if _get_value_from_index(value) == s:
                 return v.values[index]
 
@@ -563,7 +563,7 @@ class simplify_chained_calls(FuncADLNodeTransformer):
         return ast.Attribute(value=visited_value, attr=node.attr, ctx=ast.Load())
 
 
-def _get_value_from_index(arg: Union[ast.Constant, ast.Index, ast.Str]) -> Optional[int]:
+def _get_value_from_index(arg: Union[ast.Constant, ast.Index]) -> Optional[int]:
     """Deal with 3.7, and 3.8 differences in how indexing for list and tuple
     subscripts is handled.
 
@@ -575,8 +575,6 @@ def _get_value_from_index(arg: Union[ast.Constant, ast.Index, ast.Str]) -> Optio
     def extract(a: ast.Constant) -> Optional[int]:
         if isinstance(a, ast.Constant):
             return a.value
-        if isinstance(a, ast.Str):
-            return a.s
         return None
 
     if isinstance(arg, ast.Index):

--- a/func_adl/ast/function_simplifier.py
+++ b/func_adl/ast/function_simplifier.py
@@ -433,7 +433,7 @@ class simplify_chained_calls(FuncADLNodeTransformer):
         else:
             return FuncADLNodeTransformer.visit_Call(self, call_node)
 
-    def visit_Subscript_Tuple(self, v: ast.Tuple, s: Union[ast.Num, ast.Constant, ast.Index]):
+    def visit_Subscript_Tuple(self, v: ast.Tuple, s: Union[ast.Constant, ast.Index]):
         """
         (t1, t2, t3...)[1] => t2
 
@@ -452,7 +452,7 @@ class simplify_chained_calls(FuncADLNodeTransformer):
 
         return v.elts[n]
 
-    def visit_Subscript_List(self, v: ast.List, s: Union[ast.Num, ast.Constant, ast.Index]):
+    def visit_Subscript_List(self, v: ast.List, s: Union[ast.Constant, ast.Index]):
         """
         [t1, t2, t3...][1] => t2
 
@@ -469,7 +469,7 @@ class simplify_chained_calls(FuncADLNodeTransformer):
 
         return v.elts[n]
 
-    def visit_Subscript_Dict(self, v: ast.Dict, s: Union[ast.Num, ast.Constant, ast.Index]):
+    def visit_Subscript_Dict(self, v: ast.Dict, s: Union[ast.Constant, ast.Index]):
         """
         {t1, t2, t3...}[1] => t2
         """
@@ -480,7 +480,7 @@ class simplify_chained_calls(FuncADLNodeTransformer):
     def visit_Subscript_Dict_with_value(self, v: ast.Dict, s: Union[str, int]):
         "Do the lookup for the dict"
         for index, value in enumerate(v.keys):
-            assert isinstance(value, (ast.Str, ast.Constant, ast.Num))
+            assert isinstance(value, (ast.Str, ast.Constant))
             if _get_value_from_index(value) == s:
                 return v.values[index]
 
@@ -563,18 +563,16 @@ class simplify_chained_calls(FuncADLNodeTransformer):
         return ast.Attribute(value=visited_value, attr=node.attr, ctx=ast.Load())
 
 
-def _get_value_from_index(arg: Union[ast.Num, ast.Constant, ast.Index, ast.Str]) -> Optional[int]:
+def _get_value_from_index(arg: Union[ast.Constant, ast.Index, ast.Str]) -> Optional[int]:
     """Deal with 3.7, and 3.8 differences in how indexing for list and tuple
     subscripts is handled.
 
     Args:
-        arg (Union[ast.Num, ast.Constant, ast.Index]): Input ast to extract an index from.
+        arg (Union[ast.Constant, ast.Index]): Input ast to extract an index from.
                                                        Hopefully.
     """
 
-    def extract(a: Union[ast.Num, ast.Constant]) -> Optional[int]:
-        if isinstance(a, ast.Num):
-            return cast(int, a.n)
+    def extract(a: ast.Constant) -> Optional[int]:
         if isinstance(a, ast.Constant):
             return a.value
         if isinstance(a, ast.Str):

--- a/func_adl/object_stream.py
+++ b/func_adl/object_stream.py
@@ -66,7 +66,7 @@ class ObjectStream(Generic[T]):
     `Iterable[T]`).
     """
 
-    def __init__(self, the_ast: ast.AST, item_type: Type = Any):  # type: ignore
+    def __init__(self, the_ast: ast.expr, item_type: Type = Any):  # type: ignore
         r"""
         Initialize the stream with the ast that will produce this stream of objects.
         The user will almost never use this initializer.
@@ -80,7 +80,7 @@ class ObjectStream(Generic[T]):
         return self._item_type
 
     @property
-    def query_ast(self) -> ast.AST:
+    def query_ast(self) -> ast.expr:
         """Return the query `ast` that this `ObjectStream` represents
 
         Returns:
@@ -122,7 +122,7 @@ class ObjectStream(Generic[T]):
         check_ast(n_ast)
 
         return self.clone_with_new_ast(
-            function_call("SelectMany", [n_stream.query_ast, cast(ast.AST, n_ast)]),
+            function_call("SelectMany", [n_stream.query_ast, n_ast]),
             unwrap_iterable(rtn_type),
         )
 
@@ -150,7 +150,7 @@ class ObjectStream(Generic[T]):
         )
         check_ast(n_ast)
         return self.clone_with_new_ast(
-            function_call("Select", [n_stream.query_ast, cast(ast.AST, n_ast)]),
+            function_call("Select", [n_stream.query_ast, n_ast]),
             rtn_type,
         )
 
@@ -179,7 +179,7 @@ class ObjectStream(Generic[T]):
         if rtn_type != bool:
             raise ValueError(f"The Where filter must return a boolean (not {rtn_type})")
         return self.clone_with_new_ast(
-            function_call("Where", [n_stream.query_ast, cast(ast.AST, n_ast)]),
+            function_call("Where", [n_stream.query_ast, n_ast]),
             self.item_type,
         )
 

--- a/func_adl/object_stream.py
+++ b/func_adl/object_stream.py
@@ -15,7 +15,6 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    cast,
 )
 
 from make_it_sync import make_sync

--- a/func_adl/type_based_replacement.py
+++ b/func_adl/type_based_replacement.py
@@ -755,10 +755,7 @@ def remap_by_types(
                 )
 
             # Get the parameters from the subscript
-            if isinstance(slice, ast.Index):
-                parameters = ast.literal_eval(slice.value)  # type: ignore
-            else:
-                parameters = ast.literal_eval(slice)
+            parameters = ast.literal_eval(slice)
 
             # rebuild the expression, removing the slice operation and turning this into a
             # "normal" call.

--- a/func_adl/type_based_replacement.py
+++ b/func_adl/type_based_replacement.py
@@ -923,13 +923,6 @@ def remap_by_types(
             self._found_types[node] = type(node.value)
             return node
 
-        def visit_NameConstant(self, node: ast.NameConstant) -> Any:  # pragma: no cover
-            "3.7 compatibility"
-            if node.value is None:
-                raise ValueError("Do not know how to work with pythons None")
-            self._found_types[node] = bool
-            return node
-
         def visit_Attribute(self, node: ast.Attribute) -> Any:
             t_node = self.generic_visit(node)
             assert isinstance(t_node, ast.Attribute)

--- a/func_adl/type_based_replacement.py
+++ b/func_adl/type_based_replacement.py
@@ -923,11 +923,6 @@ def remap_by_types(
             self._found_types[node] = type(node.value)
             return node
 
-        def visit_Str(self, node: ast.Str) -> Any:  # pragma: no cover
-            "3.7 compatibility"
-            self._found_types[node] = str
-            return node
-
         def visit_NameConstant(self, node: ast.NameConstant) -> Any:  # pragma: no cover
             "3.7 compatibility"
             if node.value is None:

--- a/func_adl/type_based_replacement.py
+++ b/func_adl/type_based_replacement.py
@@ -923,11 +923,6 @@ def remap_by_types(
             self._found_types[node] = type(node.value)
             return node
 
-        def visit_Num(self, node: ast.Num) -> Any:  # pragma: no cover
-            "3.7 compatibility"
-            self._found_types[node] = type(node.n)
-            return node
-
         def visit_Str(self, node: ast.Str) -> Any:  # pragma: no cover
             "3.7 compatibility"
             self._found_types[node] = str

--- a/func_adl/util_ast.py
+++ b/func_adl/util_ast.py
@@ -192,7 +192,7 @@ def lambda_is_true(lam: ast.AST) -> bool:
     if not lambda_test(lam):
         return False
     rl = lambda_unwrap(lam)
-    if not isinstance(rl.body, ast.NameConstant):
+    if not isinstance(rl.body, ast.Constant):
         return False
 
     return rl.body.value is True

--- a/func_adl/util_ast.py
+++ b/func_adl/util_ast.py
@@ -83,7 +83,7 @@ def lambda_args(lam: Union[ast.Module, ast.Lambda]) -> ast.arguments:
     return lambda_unwrap(lam).args
 
 
-def lambda_body(lam: Union[ast.Lambda, ast.Module]) -> ast.AST:
+def lambda_body(lam: Union[ast.Lambda, ast.Module]) -> ast.expr:
     """
     Given an AST lambda node, get the expression it uses and return it. This just makes life
     easier, no real logic is occurring here.

--- a/tests/ast/test_func_adl_ast_utils.py
+++ b/tests/ast/test_func_adl_ast_utils.py
@@ -64,7 +64,7 @@ def test_node_transform_function_ast_with_object_args():
     assert e.count == 1
     assert len(e.args) == 1
     assert isinstance(e.args[0], ast.Constant)
-    assert e.args[0].n == 10
+    assert e.args[0].value == 10
 
 
 def test_node_transform_function_ast_with_object_args_norec():
@@ -170,7 +170,7 @@ def test_node_visit_function_ast_with_object_args():
     assert e.count == 1
     assert len(e.args) == 1
     assert isinstance(e.args[0], ast.Constant)
-    assert e.args[0].n == 10
+    assert e.args[0].value == 10
 
 
 def test_node_visit_function_ast_with_object_args_norec():

--- a/tests/ast/test_func_adl_ast_utils.py
+++ b/tests/ast/test_func_adl_ast_utils.py
@@ -63,7 +63,7 @@ def test_node_transform_function_ast_with_object_args():
     assert expected == ast.dump(e.visit(start))
     assert e.count == 1
     assert len(e.args) == 1
-    assert isinstance(e.args[0], ast.Num)
+    assert isinstance(e.args[0], ast.Constant)
     assert e.args[0].n == 10
 
 
@@ -169,7 +169,7 @@ def test_node_visit_function_ast_with_object_args():
     e.visit(start)
     assert e.count == 1
     assert len(e.args) == 1
-    assert isinstance(e.args[0], ast.Num)
+    assert isinstance(e.args[0], ast.Constant)
     assert e.args[0].n == 10
 
 

--- a/tests/test_event_dataset.py
+++ b/tests/test_event_dataset.py
@@ -59,7 +59,7 @@ def test_eds_recovery_two_ds():
     q1 = r1.Select(lambda a: a + 1)
     q2 = r2.Select(lambda b: b + 1)
 
-    q = ObjectStream(ast.BinOp(q1.query_ast, ast.Add, q2.query_ast))
+    q = ObjectStream(ast.BinOp(q1.query_ast, ast.Add, q2.query_ast))  # type: ignore
     with pytest.raises(Exception) as e:
         find_EventDataset(q.query_ast)
 
@@ -67,7 +67,7 @@ def test_eds_recovery_two_ds():
 
 
 def test_eds_recovery_no_root():
-    q = ObjectStream(ast.BinOp(ast.Constant(1), ast.Add, ast.Constant(2)))
+    q = ObjectStream(ast.BinOp(ast.Constant(1), ast.Add, ast.Constant(2)))  # type: ignore
     with pytest.raises(Exception) as e:
         find_EventDataset(q.query_ast)
 

--- a/tests/test_event_dataset.py
+++ b/tests/test_event_dataset.py
@@ -21,7 +21,7 @@ class my_event(EventDataset):
 class my_event_extra_args(EventDataset):
     def __init__(self):
         super().__init__()
-        cast(ast.Call, self.query_ast).args.append(ast.Str(s="hi"))
+        cast(ast.Call, self.query_ast).args.append(ast.Constant(value="hi"))
 
     async def execute_result_async(self, a: ast.AST) -> Any:
         return 10

--- a/tests/test_event_dataset.py
+++ b/tests/test_event_dataset.py
@@ -1,9 +1,10 @@
 import ast
-from func_adl.object_stream import ObjectStream
 from typing import Any, cast
 
 import pytest
+
 from func_adl import EventDataset, find_EventDataset
+from func_adl.object_stream import ObjectStream
 
 
 def test_cannot_create():
@@ -66,7 +67,7 @@ def test_eds_recovery_two_ds():
 
 
 def test_eds_recovery_no_root():
-    q = ObjectStream(ast.BinOp(ast.Num(1), ast.Add, ast.Num(2)))
+    q = ObjectStream(ast.BinOp(ast.Constant(1), ast.Add, ast.Constant(2)))
     with pytest.raises(Exception) as e:
         find_EventDataset(q.query_ast)
 


### PR DESCRIPTION
Since we no longer supporting Python 3.7, a lot of legacy code can be removed. This will be required anyway as we move to python 3.14 where a lot of this stuff simply disappears.

* Remove all `ast.Num` support
* Remove all `ast.Str` support
* Remove all `ast.NameConstant` support
* Update use of `ast.expr` to remove lots of `cast` operations.


Fixes #171