### PR TITLE
Data classes and Named Ntuple Support

### DIFF
--- a/func_adl/type_based_replacement.py
+++ b/func_adl/type_based_replacement.py
@@ -782,10 +782,16 @@ def remap_by_types(
             types, not the types the user thinks they may be using.
             """
             # Arguments are specified as kwargs.
-            fields: List[Tuple[str, type]] = [
+            assert isinstance(node.func, ast.Constant)
+            signature = inspect.signature(node.func.value)
+            fields_kw: List[Tuple[str, type]] = [
                 (f.arg, self.lookup_type(f.value)) for f in node.keywords if f.arg is not None
             ]
-            dict_dataclass = make_dataclass("dict_dataclass", fields)
+            fields_args: List[Tuple[str, type]] = [
+                (a_name.name, self.lookup_type(a_arg))
+                for a_name, a_arg in zip(signature.parameters.values(), node.args)
+            ]
+            dict_dataclass = make_dataclass("dict_dataclass", fields_args + fields_kw)
 
             self._found_types[node] = dict_dataclass
             return node

--- a/func_adl/type_based_replacement.py
+++ b/func_adl/type_based_replacement.py
@@ -818,9 +818,7 @@ def remap_by_types(
                             t_node.func.slice,
                             t_node.func.value,
                         )
-            elif isinstance(t_node.func, ast.Constant) and hasattr(
-                t_node.func.value, "__dataclass_fields__"
-            ):
+            elif isinstance(t_node.func, ast.Constant) and is_dataclass(t_node.func.value):
                 self.process_dataclass_creation(t_node)
             return t_node
 

--- a/func_adl/type_based_replacement.py
+++ b/func_adl/type_based_replacement.py
@@ -933,8 +933,9 @@ def remap_by_types(
             assert isinstance(t_node, ast.Dict)
 
             fields: List[Tuple[str, type]] = [
-                (ast.literal_eval(f), self.lookup_type(v))  # type: ignore
+                (ast.literal_eval(f), self.lookup_type(v))
                 for f, v in zip(t_node.keys, t_node.values)
+                if f is not None
             ]
             dict_dataclass = make_dataclass("dict_dataclass", fields)
 

--- a/func_adl/util_ast.py
+++ b/func_adl/util_ast.py
@@ -308,7 +308,14 @@ class _rewrite_captured_vars(ast.NodeTransformer):
         "If the rewritten call turns into an actual function, then we have to bail"
         old_func = node.func
         rewritten_call = cast(ast.Call, super().generic_visit(node))
-        if isinstance(rewritten_call.func, ast.Constant):
+
+        # Function calls we generally want to pass on down to the backend, without getting their generic
+        # form. OTOH, we do want to make sure that dataclasses are "used" for later
+        # translation.
+        # TODO: Make this a more robust test
+        if isinstance(rewritten_call.func, ast.Constant) and not hasattr(
+            rewritten_call.func.value, "__dataclass_fields__"
+        ):
             rewritten_call.func = old_func
 
         return rewritten_call

--- a/func_adl/util_ast.py
+++ b/func_adl/util_ast.py
@@ -4,6 +4,7 @@ import ast
 import inspect
 import tokenize
 from collections import defaultdict
+from dataclasses import is_dataclass
 from enum import Enum
 from types import ModuleType
 from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union, cast
@@ -313,8 +314,8 @@ class _rewrite_captured_vars(ast.NodeTransformer):
         # form. OTOH, we do want to make sure that dataclasses are "used" for later
         # translation.
         # TODO: Make this a more robust test
-        if isinstance(rewritten_call.func, ast.Constant) and not hasattr(
-            rewritten_call.func.value, "__dataclass_fields__"
+        if isinstance(rewritten_call.func, ast.Constant) and not is_dataclass(
+            rewritten_call.func.value
         ):
             rewritten_call.func = old_func
 

--- a/func_adl/util_ast.py
+++ b/func_adl/util_ast.py
@@ -310,10 +310,9 @@ class _rewrite_captured_vars(ast.NodeTransformer):
         old_func = node.func
         rewritten_call = cast(ast.Call, super().generic_visit(node))
 
-        # Function calls we generally want to pass on down to the backend, without getting their generic
-        # form. OTOH, we do want to make sure that dataclasses are "used" for later
-        # translation.
-        # TODO: Make this a more robust test
+        # Function calls we generally want to pass on down to the backend, without getting
+        # their generic form. OTOH, we do want to make sure that dataclasses are "used"
+        # for later translation.
         if isinstance(rewritten_call.func, ast.Constant) and not is_dataclass(
             rewritten_call.func.value
         ):

--- a/tests/test_type_based_replacement.py
+++ b/tests/test_type_based_replacement.py
@@ -633,7 +633,7 @@ def test_dictionary_through_Select_reference_slice():
     assert expr_type == Iterable[float]
 
 
-def test_dictionary_user_defined_follow_types():
+def test_dataclass_user_defined_follow_types():
     "Make sure user can define a dictionary and the type properly is propagated through"
 
     @dataclass
@@ -648,7 +648,7 @@ def test_dictionary_user_defined_follow_types():
     assert expr_type == Iterable[float]
 
 
-def test_dictionary_user_defined_follow_types_postional():
+def test_dataclass_user_defined_follow_types_postional():
     "Make sure user can define a dictionary and the type properly is propagated through"
 
     @dataclass
@@ -663,7 +663,7 @@ def test_dictionary_user_defined_follow_types_postional():
     assert expr_type == Iterable[float]
 
 
-def test_dictionary_user_defined_follow_types_combo():
+def test_dataclass_user_defined_follow_types_combo():
     "Make sure user can define a dictionary and the type properly is propagated through"
 
     @dataclass

--- a/tests/test_type_based_replacement.py
+++ b/tests/test_type_based_replacement.py
@@ -408,7 +408,7 @@ def test_collection_Custom_Method_default(caplog):
 
     @register_func_adl_os_collection
     class CustomCollection_default(ObjectStream[M]):
-        def __init__(self, a: ast.AST, item_type):
+        def __init__(self, a: ast.expr, item_type):
             super().__init__(a, item_type)
 
         def Take(self, n: int = 5) -> ObjectStream[M]: ...  # noqa
@@ -431,7 +431,7 @@ def test_collection_Custom_Method_Jet(caplog):
     M = TypeVar("M")
 
     class CustomCollection_Jet(ObjectStream[M]):
-        def __init__(self, a: ast.AST, item_type):
+        def __init__(self, a: ast.expr, item_type):
             super().__init__(a, item_type)
 
         def MyFirst(self) -> M: ...  # noqa
@@ -638,7 +638,7 @@ def test_dictionary_user_defined_follow_types():
 
     @dataclass
     class my_dc:
-        jets: Iterable[Jet]
+        jets: ObjectStream[Jet]
 
     s = parse_as_ast(lambda e: my_dc(jets=e.Jets()).jets.Select(lambda j: j.pt())).body
     objs = ObjectStream[Event](ast.Name(id="e", ctx=ast.Load()))

--- a/tests/test_type_based_replacement.py
+++ b/tests/test_type_based_replacement.py
@@ -648,6 +648,39 @@ def test_dictionary_user_defined_follow_types():
     assert expr_type == Iterable[float]
 
 
+def test_dictionary_user_defined_follow_types_postional():
+    "Make sure user can define a dictionary and the type properly is propagated through"
+
+    @dataclass
+    class my_dc:
+        jets: ObjectStream[Jet]
+
+    s = parse_as_ast(lambda e: my_dc(e.Jets()).jets.Select(lambda j: j.pt())).body
+    objs = ObjectStream[Event](ast.Name(id="e", ctx=ast.Load()))
+
+    new_objs, new_s, expr_type = remap_by_types(objs, "e", Event, s)
+
+    assert expr_type == Iterable[float]
+
+
+def test_dictionary_user_defined_follow_types_combo():
+    "Make sure user can define a dictionary and the type properly is propagated through"
+
+    @dataclass
+    class my_dc:
+        jets: ObjectStream[Jet]
+        electrons: ObjectStream[Jet]
+
+    s = parse_as_ast(
+        lambda e: my_dc(e.Jets(), electrons=e.Jets()).jets.Select(lambda j: j.pt())
+    ).body
+    objs = ObjectStream[Event](ast.Name(id="e", ctx=ast.Load()))
+
+    new_objs, new_s, expr_type = remap_by_types(objs, "e", Event, s)
+
+    assert expr_type == Iterable[float]
+
+
 def test_indexed_tuple():
     "Check that we can type-follow through tuples"
 

--- a/tests/test_type_based_replacement_py310.py
+++ b/tests/test_type_based_replacement_py310.py
@@ -1,3 +1,4 @@
+# flake8: noqa: E704
 from __future__ import annotations
 
 import ast

--- a/tests/test_type_based_replacement_py310.py
+++ b/tests/test_type_based_replacement_py310.py
@@ -29,30 +29,23 @@ def add_track_extra_info(s: ObjectStream[T], a: ast.Call) -> Tuple[ObjectStream[
 
 @func_adl_callback(add_track_extra_info)
 class TrackStuff:
-    def pt(self) -> float:
-        ...
+    def pt(self) -> float: ...
 
-    def eta(self) -> float:
-        ...
+    def eta(self) -> float: ...
 
 
 class Track:
-    def pt(self) -> float:
-        ...
+    def pt(self) -> float: ...
 
-    def eta(self) -> float:
-        ...
+    def eta(self) -> float: ...
 
 
 class Jet:
-    def pt(self) -> float:
-        ...
+    def pt(self) -> float: ...
 
-    def eta(self) -> float:
-        ...
+    def eta(self) -> float: ...
 
-    def tracks(self) -> Iterable[Track]:
-        ...
+    def tracks(self) -> Iterable[Track]: ...
 
 
 def ast_lambda(lambda_func: str) -> ast.Lambda:
@@ -70,8 +63,7 @@ def add_met_extra_info(s: ObjectStream[T], a: ast.Call) -> Tuple[ObjectStream[T]
 
 @func_adl_callback(add_met_extra_info)
 class met_extra:
-    def pxy(self) -> float:
-        ...
+    def pxy(self) -> float: ...
 
 
 def add_met_info(s: ObjectStream[T], a: ast.Call) -> Tuple[ObjectStream[T], ast.Call]:
@@ -86,18 +78,14 @@ def add_met_method_info(s: ObjectStream[T], a: ast.Call) -> Tuple[ObjectStream[T
 
 @func_adl_callback(add_met_info)
 class met:
-    def pxy(self) -> float:
-        ...
+    def pxy(self) -> float: ...
 
-    def isGood(self) -> bool:
-        ...
+    def isGood(self) -> bool: ...
 
-    def metobj(self) -> met_extra:
-        ...
+    def metobj(self) -> met_extra: ...
 
     @func_adl_callback(add_met_method_info)
-    def custom(self) -> float:
-        ...
+    def custom(self) -> float: ...
 
 
 def add_collection(s: ObjectStream[T], a: ast.Call) -> Tuple[ObjectStream[T], ast.Call]:
@@ -116,26 +104,19 @@ def add_collection(s: ObjectStream[T], a: ast.Call) -> Tuple[ObjectStream[T], as
 
 @func_adl_callback(add_collection)
 class Event:
-    def Jets(self, bank: str = "default") -> Iterable[Jet]:
-        ...
+    def Jets(self, bank: str = "default") -> Iterable[Jet]: ...
 
-    def Jets_req(self, bank_required: str) -> Iterable[Jet]:
-        ...
+    def Jets_req(self, bank_required: str) -> Iterable[Jet]: ...
 
-    def MET(self) -> met:
-        ...
+    def MET(self) -> met: ...
 
-    def MET_noreturntype(self):
-        ...
+    def MET_noreturntype(self): ...
 
-    def Tracks(self) -> Iterable[Track]:
-        ...
+    def Tracks(self) -> Iterable[Track]: ...
 
-    def TrackStuffs(self) -> Iterable[TrackStuff]:
-        ...
+    def TrackStuffs(self) -> Iterable[TrackStuff]: ...
 
-    def EventNumber(self) -> int:
-        ...
+    def EventNumber(self) -> int: ...
 
 
 def return_type_test(expr: str, arg_type: type, expected_type: type):
@@ -167,7 +148,7 @@ def test_float():
 
 
 def test_any():
-    return_type_test("e", Any, Any)
+    return_type_test("e", cast(type, Any), cast(type, Any))
 
 
 def test_neg_float():
@@ -248,11 +229,11 @@ def test_subscript():
 
 
 def test_subscript_any():
-    return_type_test("e[0]", Any, Any)
+    return_type_test("e[0]", cast(type, Any), cast(type, Any))
 
 
 def test_unknown_name(caplog):
-    return_type_test("e+cpp_any", Any, Any)
+    return_type_test("e+cpp_any", cast(type, Any), cast(type, Any))
 
     assert "cpp_any" in caplog.text
 
@@ -320,13 +301,11 @@ Result = TypeVar("Result")
 
 
 class _itsb_FADLStream(Iterable[R]):
-    def Select(self, x: Callable[[R], Result]) -> _itsb_FADLStream[Result]:
-        ...
+    def Select(self, x: Callable[[R], Result]) -> _itsb_FADLStream[Result]: ...
 
 
 class _itsb_MyTrack:
-    def pt(self) -> float:
-        ...
+    def pt(self) -> float: ...
 
 
 def test_shortcut_nested_with_iterable_subclass():
@@ -334,8 +313,7 @@ def test_shortcut_nested_with_iterable_subclass():
     inside the method are called"""
 
     class MyEvent:
-        def MyTracks(self) -> _itsb_FADLStream[_itsb_MyTrack]:
-            ...
+        def MyTracks(self) -> _itsb_FADLStream[_itsb_MyTrack]: ...
 
     s = ast_lambda(
         "ds.Select(lambda e: e.MyTracks()).Select(lambda ts: ts.Select(lambda t: t.pt()))"
@@ -491,8 +469,7 @@ def test_function_with_processor():
         return new_s, a
 
     @func_adl_callable(MySqrtProcessor)
-    def MySqrt(x: float) -> float:
-        ...
+    def MySqrt(x: float) -> float: ...
 
     s = ast_lambda("MySqrt(2)")
     objs = ObjectStream[Event](ast.Name(id="e", ctx=ast.Load()), item_type=Event)
@@ -509,8 +486,7 @@ def test_function_with_simple():
     "Define a function we can use"
 
     @func_adl_callable()
-    def MySqrt(x: float) -> float:
-        ...
+    def MySqrt(x: float) -> float: ...
 
     s = ast_lambda("MySqrt(2)")
     objs = ObjectStream[Event](ast.Name(id="e", ctx=ast.Load()))
@@ -526,8 +502,7 @@ def test_function_with_missing_arg():
     "Define a function we can use"
 
     @func_adl_callable()
-    def MySqrt(my_x: float) -> float:
-        ...
+    def MySqrt(my_x: float) -> float: ...
 
     s = ast_lambda("MySqrt()")
     objs = ObjectStream[Event](ast.Name(id="e", ctx=ast.Load()))
@@ -542,8 +517,7 @@ def test_function_with_default():
     "Define a function we can use"
 
     @func_adl_callable()
-    def MySqrt(x: float = 20) -> float:
-        ...
+    def MySqrt(x: float = 20) -> float: ...
 
     s = ast_lambda("MySqrt()")
     objs = ObjectStream[Event](ast.Name(id="e", ctx=ast.Load()))
@@ -559,8 +533,7 @@ def test_function_with_keyword():
     "Define a function we can use"
 
     @func_adl_callable()
-    def MySqrt(x: float = 20) -> float:
-        ...
+    def MySqrt(x: float = 20) -> float: ...
 
     s = ast_lambda("MySqrt(x=15)")
     objs = ObjectStream[Event](ast.Name(id="e", ctx=ast.Load()))

--- a/tests/test_util_ast.py
+++ b/tests/test_util_ast.py
@@ -1,5 +1,6 @@
 import ast
 import sys
+from dataclasses import dataclass
 from enum import Enum
 from typing import Callable, cast
 
@@ -311,6 +312,16 @@ def test_parse_lambda_imported_class():
 
     r = parse_as_ast(lambda e: np.cos(e))
     assert "np.cos" in ast.unparse(r)
+
+
+def test_parse_dataclass_reference():
+    @dataclass
+    class my_data_class:
+        x: int
+
+    r = parse_as_ast(lambda e: my_data_class(x=e))
+
+    assert "<locals>.my_data_class" in ast.unparse(r)
 
 
 def test_parse_simple_func():

--- a/tests/test_util_ast.py
+++ b/tests/test_util_ast.py
@@ -304,6 +304,15 @@ def test_parse_lambda_class_constant_in_module():
     assert ast.unparse(r) == ast.unparse(r_true)
 
 
+def test_parse_lambda_imported_class():
+    "Check that numpy and similar are properly passed"
+
+    import numpy as np
+
+    r = parse_as_ast(lambda e: np.cos(e))
+    assert "np.cos" in ast.unparse(r)
+
+
 def test_parse_simple_func():
     "A oneline function defined at local scope"
 


### PR DESCRIPTION
* User defined `dataclasses` are now type followed

## Minor

* Refine how we decide to pass down module references (resolve or save). Tests were added to make sure this was protected in the future.

Fixes #63
