### PR TITLE
Add dataclasses and named tuples as syntatic sugar

### DIFF
--- a/func_adl/ast/syntatic_sugar.py
+++ b/func_adl/ast/syntatic_sugar.py
@@ -1,7 +1,7 @@
 import ast
 import inspect
 from dataclasses import is_dataclass
-from typing import Any, List, Tuple
+from typing import Any, List
 
 from func_adl.util_ast import lambda_build
 
@@ -95,8 +95,10 @@ def resolve_syntatic_sugar(a: ast.AST) -> ast.AST:
                 and isinstance(a.func, ast.Constant)
                 and is_dataclass(a.func.value)
             ):
+                assert isinstance(a.func, ast.Constant)
+
                 # We have a dataclass. Turn it into a dictionary
-                signature = inspect.signature(a.func.value)
+                signature = inspect.signature(a.func.value)  # type: ignore
                 sig_arg_names = [p.name for p in signature.parameters.values()]
 
                 if len(sig_arg_names) < (len(a.args) + len(a.keywords)):
@@ -114,13 +116,14 @@ def resolve_syntatic_sugar(a: ast.AST) -> ast.AST:
 
                 for name in arg_lookup.keys():
                     if name not in sig_arg_names:
+                        assert isinstance(a.func, ast.Constant)
                         raise ValueError(
                             f"Argument {name} not found in dataclass {a.func.value}"
                             f" - {ast.unparse(node)}."
                         )
 
                 return ast.Dict(
-                    keys=arg_names,
+                    keys=arg_names,  # type: ignore
                     values=arg_values,
                 )
 

--- a/func_adl/util_ast.py
+++ b/func_adl/util_ast.py
@@ -309,8 +309,9 @@ class _rewrite_captured_vars(ast.NodeTransformer):
         "If the rewritten call turns into an actual function, then we have to bail,"
         old_func = node.func
         rewritten_call = cast(ast.Call, super().generic_visit(node))
-        if isinstance(rewritten_call.func, ast.Constant) and not is_dataclass(
-            rewritten_call.func.value
+        if isinstance(rewritten_call.func, ast.Constant) and not (
+            is_dataclass(rewritten_call.func.value)
+            or hasattr(rewritten_call.func.value, "_fields")
         ):
             rewritten_call.func = old_func
 

--- a/func_adl/util_ast.py
+++ b/func_adl/util_ast.py
@@ -4,6 +4,7 @@ import ast
 import inspect
 import tokenize
 from collections import defaultdict
+from dataclasses import is_dataclass
 from enum import Enum
 from types import ModuleType
 from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union, cast
@@ -305,10 +306,12 @@ class _rewrite_captured_vars(ast.NodeTransformer):
         return v
 
     def visit_Call(self, node: ast.Call) -> Any:
-        "If the rewritten call turns into an actual function, then we have to bail"
+        "If the rewritten call turns into an actual function, then we have to bail,"
         old_func = node.func
         rewritten_call = cast(ast.Call, super().generic_visit(node))
-        if isinstance(rewritten_call.func, ast.Constant):
+        if isinstance(rewritten_call.func, ast.Constant) and not is_dataclass(
+            rewritten_call.func.value
+        ):
             rewritten_call.func = old_func
 
         return rewritten_call

--- a/tests/ast/test_syntatic_sugar.py
+++ b/tests/ast/test_syntatic_sugar.py
@@ -1,4 +1,5 @@
 import ast
+from collections import namedtuple
 from dataclasses import dataclass
 
 import pytest
@@ -172,3 +173,53 @@ def test_resolve_dataclass_bad_args():
             lambda e: dc_1(z=e.Jets()).x.Select(lambda j: j.pt())  # type: ignore
         ).body
         resolve_syntatic_sugar(a)
+
+
+def test_resolve_named_tuple_no_args():
+    "Make sure a named tuple becomes a dictionary"
+
+    nt_1 = namedtuple("nt_1", ["x", "y"])
+
+    a = parse_as_ast(lambda e: nt_1(e.Jets(), e.Electrons()).x.Select(lambda j: j.pt())).body
+    a_resolved = resolve_syntatic_sugar(a)
+
+    a_expected = ast.parse("{'x': e.Jets(), 'y': e.Electrons()}.x.Select(lambda j: j.pt())")
+    assert ast.unparse(a_resolved) == ast.unparse(a_expected)
+
+
+def test_resolve_named_tuple_too_few_args():
+    "Make sure a named tuple becomes a dictionary"
+
+    nt_1 = namedtuple("nt_1", ["x", "y"])
+
+    a = parse_as_ast(lambda e: nt_1(e.Jets()).x.Select(lambda j: j.pt())).body  # type: ignore
+    a_resolved = resolve_syntatic_sugar(a)
+
+    a_expected = ast.parse("{'x': e.Jets()}.x.Select(lambda j: j.pt())")
+    assert ast.unparse(a_resolved) == ast.unparse(a_expected)
+
+
+def test_resolve_named_tuple_too_many_args():
+    "Make sure a named tuple becomes a dictionary"
+
+    nt_1 = namedtuple("nt_1", ["x", "y"])
+
+    with pytest.raises(ValueError):
+        a = parse_as_ast(
+            lambda e: nt_1(e.Jets(), e.Electrons(), e.Muons(), e.Jets()).x.Select(  # type: ignore
+                lambda j: j.pt()
+            )  # type: ignore
+        ).body
+        resolve_syntatic_sugar(a)
+
+
+def test_resolve_named_tuple_kwards():
+    "Make sure a named tuple becomes a dictionary"
+
+    nt_1 = namedtuple("nt_1", ["x", "y"])
+
+    a = parse_as_ast(lambda e: nt_1(x=e.Jets(), y=e.Electrons()).x.Select(lambda j: j.pt())).body
+    a_resolved = resolve_syntatic_sugar(a)
+
+    a_expected = ast.parse("{'x': e.Jets(), 'y': e.Electrons()}.x.Select(lambda j: j.pt())")
+    assert ast.unparse(a_resolved) == ast.unparse(a_expected)

--- a/tests/ast/test_syntatic_sugar.py
+++ b/tests/ast/test_syntatic_sugar.py
@@ -77,13 +77,18 @@ def test_resolve_no_async():
     assert "can't be async" in str(e)
 
 
+class LocalJet:
+    def pt(self) -> float:
+        return 0.0
+
+
 def test_resolve_dataclass_no_args():
     "Make sure a dataclass becomes a dictionary"
 
     @dataclass
     class dc_1:
-        x: ObjectStream[int]
-        y: ObjectStream[int]
+        x: ObjectStream[LocalJet]
+        y: ObjectStream[LocalJet]
 
     a = parse_as_ast(lambda e: dc_1(e.Jets(), e.Electrons()).x.Select(lambda j: j.pt())).body
     a_resolved = resolve_syntatic_sugar(a)
@@ -97,8 +102,8 @@ def test_resolve_dataclass_named_args():
 
     @dataclass
     class dc_1:
-        x: ObjectStream[int]
-        y: ObjectStream[int]
+        x: ObjectStream[LocalJet]
+        y: ObjectStream[LocalJet]
 
     a = parse_as_ast(lambda e: dc_1(x=e.Jets(), y=e.Electrons()).x.Select(lambda j: j.pt())).body
     a_resolved = resolve_syntatic_sugar(a)
@@ -112,8 +117,8 @@ def test_resolve_dataclass_mixed_args():
 
     @dataclass
     class dc_1:
-        x: ObjectStream[int]
-        y: ObjectStream[int]
+        x: ObjectStream[LocalJet]
+        y: ObjectStream[LocalJet]
 
     a = parse_as_ast(lambda e: dc_1(e.Jets(), y=e.Electrons()).x.Select(lambda j: j.pt())).body
     a_resolved = resolve_syntatic_sugar(a)
@@ -127,10 +132,10 @@ def test_resolve_dataclass_too_few_args():
 
     @dataclass
     class dc_1:
-        x: ObjectStream[int]
-        y: ObjectStream[int]
+        x: ObjectStream[LocalJet]
+        y: ObjectStream[LocalJet]
 
-    a = parse_as_ast(lambda e: dc_1(e.Jets()).x.Select(lambda j: j.pt())).body
+    a = parse_as_ast(lambda e: dc_1(e.Jets()).x.Select(lambda j: j.pt())).body  # type: ignore
     a_resolved = resolve_syntatic_sugar(a)
 
     a_expected = ast.parse("{'x': e.Jets()}.x.Select(lambda j: j.pt())")
@@ -142,12 +147,14 @@ def test_resolve_dataclass_too_many_args():
 
     @dataclass
     class dc_1:
-        x: ObjectStream[int]
-        y: ObjectStream[int]
+        x: ObjectStream[LocalJet]
+        y: ObjectStream[LocalJet]
 
     with pytest.raises(ValueError):
         a = parse_as_ast(
-            lambda e: dc_1(e.Jets(), e.Electrons(), e.Muons(), e.Jets()).x.Select(lambda j: j.pt())
+            lambda e: dc_1(e.Jets(), e.Electrons(), e.Muons(), e.Jets()).x.Select(  # type: ignore
+                lambda j: j.pt()
+            )  # type: ignore
         ).body
         resolve_syntatic_sugar(a)
 
@@ -157,9 +164,11 @@ def test_resolve_dataclass_bad_args():
 
     @dataclass
     class dc_1:
-        x: ObjectStream[int]
-        y: ObjectStream[int]
+        x: ObjectStream[LocalJet]
+        y: ObjectStream[LocalJet]
 
     with pytest.raises(ValueError):
-        a = parse_as_ast(lambda e: dc_1(z=e.Jets()).x.Select(lambda j: j.pt())).body
+        a = parse_as_ast(
+            lambda e: dc_1(z=e.Jets()).x.Select(lambda j: j.pt())  # type: ignore
+        ).body
         resolve_syntatic_sugar(a)

--- a/tests/test_type_based_replacement.py
+++ b/tests/test_type_based_replacement.py
@@ -406,7 +406,7 @@ def test_collection_Custom_Method_default(caplog):
 
     @register_func_adl_os_collection
     class CustomCollection_default(ObjectStream[M]):
-        def __init__(self, a: ast.AST, item_type):
+        def __init__(self, a: ast.expr, item_type):
             super().__init__(a, item_type)
 
         def Take(self, n: int = 5) -> ObjectStream[M]: ...  # noqa
@@ -429,7 +429,7 @@ def test_collection_Custom_Method_Jet(caplog):
     M = TypeVar("M")
 
     class CustomCollection_Jet(ObjectStream[M]):
-        def __init__(self, a: ast.AST, item_type):
+        def __init__(self, a: ast.expr, item_type):
             super().__init__(a, item_type)
 
         def MyFirst(self) -> M: ...  # noqa

--- a/tests/test_util_ast.py
+++ b/tests/test_util_ast.py
@@ -1,6 +1,7 @@
 import ast
-from dataclasses import dataclass
 import sys
+from collections import namedtuple
+from dataclasses import dataclass
 from enum import Enum
 from typing import Callable, cast
 
@@ -322,6 +323,15 @@ def test_parse_dataclass_reference():
     r = parse_as_ast(lambda e: my_data_class(x=e))
 
     assert "<locals>.my_data_class" in ast.unparse(r)
+
+
+def test_parse_named_tuple_reference():
+
+    MyDataClass = namedtuple("MyDataClass", ["x"])
+
+    r = parse_as_ast(lambda e: MyDataClass(x=e))
+
+    assert "test_util_ast.MyDataClass" in ast.unparse(r)
 
 
 def test_parse_simple_func():

--- a/tests/test_util_ast.py
+++ b/tests/test_util_ast.py
@@ -1,4 +1,5 @@
 import ast
+from dataclasses import dataclass
 import sys
 from enum import Enum
 from typing import Callable, cast
@@ -302,6 +303,25 @@ def test_parse_lambda_class_constant_in_module():
     r_true = parse_as_ast(lambda x: x > 22)
 
     assert ast.unparse(r) == ast.unparse(r_true)
+
+
+def test_parse_lambda_imported_class():
+    "Check that numpy and similar are properly passed"
+
+    import numpy as np
+
+    r = parse_as_ast(lambda e: np.cos(e))
+    assert "np.cos" in ast.unparse(r)
+
+
+def test_parse_dataclass_reference():
+    @dataclass
+    class my_data_class:
+        x: int
+
+    r = parse_as_ast(lambda e: my_data_class(x=e))
+
+    assert "<locals>.my_data_class" in ast.unparse(r)
 
 
 def test_parse_simple_func():


### PR DESCRIPTION
* Dataclasses are replaced by dictionaries as syntatic sugar
* named tuples are also replaced by dictionaries as syntatic sugar

These changes should enable the user to build a EDM with a dataclass or named tuple, and have type checking follow it!

Fixes #63