### PR TITLE
deep copy for deref tuple, list, dict

### DIFF
--- a/func_adl/ast/function_simplifier.py
+++ b/func_adl/ast/function_simplifier.py
@@ -470,7 +470,7 @@ class simplify_chained_calls(FuncADLNodeTransformer):
                 f" only {len(v.elts)} values long."
             )
 
-        return v.elts[n]
+        return copy.deepcopy(v.elts[n])
 
     def visit_Subscript_Dict(self, v: ast.Dict, s: ast.Constant):
         """

--- a/func_adl/ast/function_simplifier.py
+++ b/func_adl/ast/function_simplifier.py
@@ -485,7 +485,7 @@ class simplify_chained_calls(FuncADLNodeTransformer):
         for index, value in enumerate(v.keys):
             assert isinstance(value, ast.Constant)
             if value.value == s:
-                return v.values[index]
+                return copy.deepcopy(v.values[index])
 
         return ast.Subscript(v, s, ast.Load())  # type: ignore
 

--- a/func_adl/ast/function_simplifier.py
+++ b/func_adl/ast/function_simplifier.py
@@ -453,7 +453,7 @@ class simplify_chained_calls(FuncADLNodeTransformer):
                 f" {len(v.elts)} values long."
             )
 
-        return v.elts[n]
+        return copy.deepcopy(v.elts[n])
 
     def visit_Subscript_List(self, v: ast.List, s: ast.Constant):
         """

--- a/tests/ast/test_function_simplifier.py
+++ b/tests/ast/test_function_simplifier.py
@@ -195,6 +195,14 @@ def test_list_select():
     util_process("[t1,t2][0]", "t1")
 
 
+def test_list_select_copy_made():
+    # [t1, t2][0] should be t1.
+    root = ast.parse("[t1,t2][0]")
+    orig = root.body[0].value.value.elts[0]  # type: ignore
+    r1 = util_process(root, "t1")
+    assert r1.body[0].value != orig
+
+
 def test_tuple_select_past_end():
     # This should cause a crash!
     try:

--- a/tests/ast/test_function_simplifier.py
+++ b/tests/ast/test_function_simplifier.py
@@ -190,6 +190,14 @@ def test_tuple_select():
     util_process("(t1,t2)[0]", "t1")
 
 
+def test_tuple_select_copy_made():
+    # (t1, t2)[0] should be t1.
+    root = ast.parse("(t1,t2)[0]")
+    orig = root.body[0].value.value.elts[0]  # type: ignore
+    r1 = util_process(root, "t1")
+    assert r1.body[0].value != orig
+
+
 def test_list_select():
     # [t1, t2][0] should be t1.
     util_process("[t1,t2][0]", "t1")


### PR DESCRIPTION
* A tuple, list, or dict deref will make a deep copy of the resulting ast
* Code that depends on this depends on attaching resolution results to the ast object.
* If the same thing is de-referenced in two places, its context can change (and thus the evaluation), which will be hidden.

Fixes #183