### PR TITLE
Improve error message when you forget to parameterize a call with [cpp_xxx]

### DIFF
--- a/func_adl/type_based_replacement.py
+++ b/func_adl/type_based_replacement.py
@@ -329,6 +329,13 @@ def _fill_in_default_arguments(func: Callable, call: ast.Call) -> Tuple[ast.Call
     Returns:
         Tuple[ast.Call, Type]: The modified call site and return type.
     """
+    if not callable(func):
+        raise ValueError(
+            f"The name '{ast.unparse(call.func)}' in the expression '{ast.unparse(call)}' is "
+            f"not actually a function or method ({func}). Could it need to be parameterized"
+            f" with a '[cpp_vfloat]' or similar?"
+        )
+
     sig = inspect.signature(func)
     i_arg = 0
     arg_array = list(call.args)


### PR DESCRIPTION
* Detect the user is trying to call soemthing that isn't a method/function, and print an error message with context.

Fixes #160