### PR TITLE
Enum pass through

### DIFF
--- a/func_adl/type_based_replacement.py
+++ b/func_adl/type_based_replacement.py
@@ -906,7 +906,8 @@ def remap_by_types(
             elif node.id in _global_functions:
                 self._found_types[node] = Callable
             else:
-                logging.getLogger(__name__).warning(f"Unknown type for name {node.id}")
+                if not getattr(node, "_ignore", False):
+                    logging.getLogger(__name__).warning(f"Unknown type for name {node.id}")
                 self._found_types[node] = Any
             return node
 

--- a/func_adl/util_ast.py
+++ b/func_adl/util_ast.py
@@ -293,7 +293,13 @@ class _rewrite_captured_vars(ast.NodeTransformer):
             new_value = getattr(value.value, node.attr)
             # When 3.10 is not supported, replace with EnumType
             if isinstance(value.value, Enum.__class__):
-                return node
+                import importlib
+
+                enum_mod = importlib.import_module(new_value.__module__)
+                additional_ns = getattr(enum_mod, "_object_cpp_as_py_namespace", "")
+                if len(additional_ns) == 0:
+                    return node
+                return ast.parse(f"{additional_ns}.{ast.unparse(node)}").body[0].value
             return ast.Constant(value=new_value)
 
         # If we fail, then just move on.

--- a/func_adl/util_ast.py
+++ b/func_adl/util_ast.py
@@ -293,7 +293,7 @@ class _rewrite_captured_vars(ast.NodeTransformer):
             new_value = getattr(value.value, node.attr)
             # When 3.10 is not supported, replace with EnumType
             if isinstance(value.value, Enum.__class__):
-                new_value = new_value.value
+                return node
             return ast.Constant(value=new_value)
 
         # If we fail, then just move on.

--- a/func_adl/util_ast.py
+++ b/func_adl/util_ast.py
@@ -299,7 +299,9 @@ class _rewrite_captured_vars(ast.NodeTransformer):
                 additional_ns = getattr(enum_mod, "_object_cpp_as_py_namespace", "")
                 if len(additional_ns) == 0:
                     return node
-                return ast.parse(f"{additional_ns}.{ast.unparse(node)}").body[0].value
+                return (
+                    ast.parse(f"{additional_ns}.{ast.unparse(node)}").body[0].value  # type: ignore
+                )
             return ast.Constant(value=new_value)
 
         # If we fail, then just move on.

--- a/tests/test_type_based_replacement.py
+++ b/tests/test_type_based_replacement.py
@@ -3,7 +3,7 @@ import copy
 import inspect
 import logging
 from inspect import isclass
-from typing import Any, Callable, Iterable, Optional, Tuple, Type, TypeVar, cast
+from typing import Any, Callable, Iterable, Optional, Tuple, Type, TypeVar, Union, cast
 
 import pytest
 
@@ -128,7 +128,7 @@ class Event:
     def MyLambdaCallback(self, cb: Callable) -> int: ...  # noqa
 
 
-def return_type_test(expr: str | ast.expr, arg_type: type, expected_type: type):
+def return_type_test(expr: Union[str, ast.expr], arg_type: type, expected_type: type):
     s = expr if isinstance(expr, ast.expr) else ast_lambda(expr)
     objs = ObjectStream(ast.Name(id="e", ctx=ast.Load()), arg_type)
 

--- a/tests/test_util_ast.py
+++ b/tests/test_util_ast.py
@@ -296,6 +296,26 @@ def test_parse_lambda_class_enum():
     assert "VALUE" in ast.unparse(r)
 
 
+def test_parse_lambda_with_implied_ns():
+    "Test adding the special attribute to the module to prefix a namespace"
+    # Add the attribute to the module
+    global _object_cpp_as_py_namespace
+    _object_cpp_as_py_namespace = "aweful"
+
+    try:
+
+        class forkit:
+            class MyEnum(Enum):
+                VALUE = 20
+
+        r = parse_as_ast(lambda x: x > forkit.MyEnum.VALUE)
+
+        assert "aweful.forkit.MyEnum.VALUE" in ast.unparse(r)
+    finally:
+        # Remove the attribute from the module
+        del _object_cpp_as_py_namespace
+
+
 def test_parse_lambda_class_constant_in_module():
     from . import xAOD
 

--- a/tests/test_util_ast.py
+++ b/tests/test_util_ast.py
@@ -311,6 +311,20 @@ def test_parse_lambda_with_implied_ns():
         r = parse_as_ast(lambda x: x > forkit.MyEnum.VALUE)
 
         assert "aweful.forkit.MyEnum.VALUE" in ast.unparse(r)
+
+        found_it = False
+
+        class check_it(ast.NodeVisitor):
+            def visit_Name(self, node: ast.Name):
+                nonlocal found_it
+                if node.id == "aweful":
+                    found_it = True
+                    assert hasattr(node, "_ignore")
+                    assert node._ignore  # type: ignore
+
+        check_it().visit(r)
+        assert found_it
+
     finally:
         # Remove the attribute from the module
         del _object_cpp_as_py_namespace

--- a/tests/test_util_ast.py
+++ b/tests/test_util_ast.py
@@ -292,9 +292,8 @@ def test_parse_lambda_class_enum():
             VALUE = 20
 
     r = parse_as_ast(lambda x: x > forkit.MyEnum.VALUE)
-    r_true = parse_as_ast(lambda x: x > 20)
 
-    assert ast.unparse(r) == ast.unparse(r_true)
+    assert "VALUE" in ast.unparse(r)
 
 
 def test_parse_lambda_class_constant_in_module():

--- a/tests/test_util_ast.py
+++ b/tests/test_util_ast.py
@@ -330,6 +330,40 @@ def test_parse_lambda_with_implied_ns():
         del _object_cpp_as_py_namespace
 
 
+def test_parse_lambda_with_implied_ns_empty():
+    "Test adding the special attribute to the module to prefix a namespace"
+    # Add the attribute to the module
+    global _object_cpp_as_py_namespace
+    _object_cpp_as_py_namespace = ""
+
+    try:
+
+        class forkit:
+            class MyEnum(Enum):
+                VALUE = 20
+
+        r = parse_as_ast(lambda x: x > forkit.MyEnum.VALUE)
+
+        assert "forkit.MyEnum.VALUE" in ast.unparse(r)
+
+        found_it = False
+
+        class check_it(ast.NodeVisitor):
+            def visit_Name(self, node: ast.Name):
+                nonlocal found_it
+                if node.id == "forkit":
+                    found_it = True
+                    assert hasattr(node, "_ignore")
+                    assert node._ignore  # type: ignore
+
+        check_it().visit(r)
+        assert found_it
+
+    finally:
+        # Remove the attribute from the module
+        del _object_cpp_as_py_namespace
+
+
 def test_parse_lambda_class_constant_in_module():
     from . import xAOD
 


### PR DESCRIPTION
* Enum anywhere in the code is properly marked as an enum

NOTE: This does not trigger a download of the enum spec as metadata - that is really up to the user and the type library. If the enum is returned or used in a call, the type specs will do this for you. But if you are writting some C++ code that does the call, then you are responsible for this yourself!

Fixes #179