### PR TITLE
Feat/nested_functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ good_met = good_met_expr.value()
 
 The cut will be applied at 40, because that was the value of `met_cut` when the `Where` function was called. This will also work for variables captured inside functions.
 
+## Captured Functions
+
+It is possible to capture _simple_ functions as well.
+
+```python
+def good_jet(jet):
+    return jet.pt() > 40.0
+
+good_met_expr = ds_of_jets.Where(lambda jet: good_jet(jet))
+```
+
+Simple means that you must restrict the function to a single `return` statement. No multi-statement functions are currently possible, even if they reduce to a single statement! Also, a recursive function will give you undefined (and likely ugly) behavior.
+
 ## Syntatic Sugar
 
 There are several python expressions and idioms that are translated behind your back to `func_adl`. Note that these must occur inside one of the `ObjectStream` method's `lambda` functions like `Select`, `SelectMany`, or `Where`.

--- a/func_adl/object_stream.py
+++ b/func_adl/object_stream.py
@@ -185,7 +185,10 @@ class ObjectStream(Generic[T]):
         )
         check_ast(n_ast)
         if rtn_type != bool:
-            raise ValueError(f"The Where filter must return a boolean (not {rtn_type})")
+            raise ValueError(
+                f"The Where filter must return a boolean (not {rtn_type}) for expression "
+                f"{ast.unparse(n_ast)}"
+            )
         return self.clone_with_new_ast(
             function_call("Where", [n_stream.query_ast, n_ast]),
             self.item_type,

--- a/func_adl/object_stream.py
+++ b/func_adl/object_stream.py
@@ -88,7 +88,7 @@ class ObjectStream(Generic[T]):
         return self._q_ast
 
     def clone_with_new_ast(self, new_ast: ast.AST, new_type: type[S]) -> ObjectStream[S]:
-        clone = copy.deepcopy(self)
+        clone = copy.copy(self)
         clone._q_ast = new_ast
         clone._item_type = new_type
         return clone  # type: ignore

--- a/func_adl/util_ast.py
+++ b/func_adl/util_ast.py
@@ -237,18 +237,21 @@ def rewrite_func_as_lambda(f: ast.FunctionDef) -> ast.Lambda:
         - It is assumed that the ast passed in won't be altered in place - no deep copy is
           done of the statement or args - they are just re-used.
     """
-    if len(f.body) != 1:
+    interesting_body = [
+        b for b in f.body if not (isinstance(b, ast.Expr) and isinstance(b.value, ast.Constant))
+    ]
+    if len(interesting_body) != 1:
         raise ValueError(
             f'Can handle simple functions of only one line - "{f.name}"' f" has {len(f.body)}."
         )
-    if not isinstance(f.body[0], ast.Return):
+    if not isinstance(interesting_body[0], ast.Return):
         raise ValueError(
             f'Simple function must use return statement - "{f.name}" does ' "not seem to."
         )
 
     # the arguments
     args = f.args
-    ret = cast(ast.Return, f.body[0])
+    ret = cast(ast.Return, interesting_body[0])
     return ast.Lambda(args, ret.value)  # type: ignore
 
 

--- a/tests/test_util_ast.py
+++ b/tests/test_util_ast.py
@@ -414,6 +414,50 @@ def test_parse_simple_func():
     assert isinstance(f.body, ast.BinOp)
 
 
+def test_parse_nested_func():
+    "A oneline function defined at local scope"
+
+    def func_1(x):
+        return x + 1
+
+    def func_2(x):
+        return func_1(x) + 2
+
+    f = parse_as_ast(func_2)
+
+    assert ast.unparse(f) == "lambda x: (lambda x: x + 1)(x) + 2"
+
+
+def test_parse_nested_empty_func():
+    "A oneline function defined at local scope"
+
+    def func_1(x) -> int:
+        ...
+
+    def func_2(x) -> int:
+        return func_1(x) + 2
+
+    f = parse_as_ast(func_2)
+
+    assert ast.unparse(f) == "lambda x: func_1(x) + 2"
+
+
+def test_parse_nested_complex_func():
+    "A oneline function defined at local scope"
+
+    def func_1(x) -> int:
+        if x > 10:
+            return 5
+        return 20
+
+    def func_2(x) -> int:
+        return func_1(x) + 2
+
+    f = parse_as_ast(func_2)
+
+    assert ast.unparse(f) == "lambda x: func_1(x) + 2"
+
+
 def global_doit(x):
     return x + 1
 

--- a/tests/test_util_ast.py
+++ b/tests/test_util_ast.py
@@ -414,6 +414,20 @@ def test_parse_simple_func():
     assert isinstance(f.body, ast.BinOp)
 
 
+def test_parse_simple_func_with_info():
+    "A oneline function defined at local scope"
+
+    def doit(x: int) -> int:
+        "Add one to the arg"
+        return x + 1
+
+    f = parse_as_ast(doit)
+
+    assert isinstance(f, ast.Lambda)
+    assert len(f.args.args) == 1
+    assert isinstance(f.body, ast.BinOp)
+
+
 def test_parse_nested_func():
     "A oneline function defined at local scope"
 
@@ -431,8 +445,7 @@ def test_parse_nested_func():
 def test_parse_nested_empty_func():
     "A oneline function defined at local scope"
 
-    def func_1(x) -> int:
-        ...
+    def func_1(x) -> int: ...
 
     def func_2(x) -> int:
         return func_1(x) + 2


### PR DESCRIPTION
* Explicit lambda calls are translated (`(lambda x: x + 1)(y)` -> `y + 1`). This should not be noticed by the user.
* Clean up a extra (undeeded) `deepcopy`.
* Updated readme for the below.
* You can use a simple nested function in your `func_adl` expressions.

```python
def good_jet(j):
  return j.pt() > 40
```

Fixes #187
