### PR TITLE
Make sure Range isn't Replaced

### DIFF
--- a/func_adl/functions.py
+++ b/func_adl/functions.py
@@ -1,5 +1,5 @@
 import ast
-from typing import Union, cast
+from typing import Union
 
 from .object_stream import ObjectStream
 from .util_ast import as_ast, function_call
@@ -7,7 +7,7 @@ from .util_ast import as_ast, function_call
 
 def Range(
     lower_bound: Union[str, int, ast.AST], upper_bound: Union[str, int, ast.AST]
-) -> ObjectStream:
+) -> ObjectStream[int]:
     r"""
     Given the lower and upper bound return an object with the range of numbers, similar to python
     range
@@ -23,8 +23,4 @@ def Range(
 
     """
 
-    return ObjectStream(
-        function_call(
-            "Range", [cast(ast.AST, as_ast(lower_bound)), cast(ast.AST, as_ast(upper_bound))]
-        )
-    )
+    return ObjectStream(function_call("Range", [as_ast(lower_bound), as_ast(upper_bound)]))

--- a/func_adl/functions.py
+++ b/func_adl/functions.py
@@ -2,7 +2,6 @@ import ast
 from typing import Union
 
 from .object_stream import ObjectStream
-from .util_ast import as_ast, function_call
 
 
 def Range(
@@ -20,7 +19,5 @@ def Range(
     Return:
 
         A new ObjectStream that contains the range of numbers
-
     """
-
-    return ObjectStream(function_call("Range", [as_ast(lower_bound), as_ast(upper_bound)]))
+    ...

--- a/tests/test_util_ast.py
+++ b/tests/test_util_ast.py
@@ -1091,3 +1091,17 @@ def test_check_ast_bad():
         check_ast(a)
 
     assert "my_type" in str(e)
+
+
+def test_Select_inline():
+    "Make sure nothing funny happens to Select"
+    r = parse_as_ast(lambda jets: jets.Select(lambda j: j.pt()))
+    assert "function_call" not in ast.unparse(r)
+
+
+def test_Range_inline():
+    "Make sure nothing funny happens to Range"
+    from func_adl import Range
+
+    r = parse_as_ast(lambda jets: Range(1, 10).Select(lambda j: j + 1))
+    assert "function_call" not in ast.unparse(r)


### PR DESCRIPTION
The `Range` function was including some unecessary code - which was accidentally triggering some funny behavior in the xAOD backend.

Fixes #189