### PR TITLE
Fix parsing of multiline lambda dictionaries

### DIFF
--- a/func_adl/util_ast.py
+++ b/func_adl/util_ast.py
@@ -590,6 +590,18 @@ def _get_lambda_in_stream(
         if t.type == tokenize.NEWLINE or t.string == "\n":
             saw_new_line = True
 
+    # Some versions of python (3.10 and 3.11) will leave a stray NEWLINE or
+    # DEDENT token at the end of the lambda when pulling tokens out of the
+    # tokenizer. These can cause ``tokenize.untokenize`` to crash as the
+    # indentation levels will not match. Strip them off before converting back
+    # into source code.
+    while accumulated_tokens and accumulated_tokens[-1].type in (
+        tokenize.NEWLINE,
+        tokenize.NL,
+        tokenize.DEDENT,
+    ):
+        accumulated_tokens.pop()
+
     function_source = "(" + tokenize.untokenize(accumulated_tokens).lstrip() + ")"
     a_module = ast.parse(function_source)
     lda = next(

--- a/tests/test_util_ast.py
+++ b/tests/test_util_ast.py
@@ -1105,3 +1105,27 @@ def test_Range_inline():
 
     r = parse_as_ast(lambda jets: Range(1, 10).Select(lambda j: j + 1))
     assert "function_call" not in ast.unparse(r)
+
+
+def test_parse_lambda_multiline_dictionary():
+    """Multi-line lambda returning a dictionary should parse"""
+
+    pdgid = 13
+
+    found = []
+
+    class my_obj:
+        def Select(self, f: Callable):
+            found.append(parse_as_ast(f))
+            return self
+
+    my_obj().Select(
+        lambda particles: {
+            "good": particles.Where(lambda p: p.pdgId() == pdgid).Where(lambda p: p.hasDecayVtx()),
+            "none_count": particles.Where(lambda p: p.pdgId() == pdgid)
+            .Where(lambda p: not p.hasDecayVtx())
+            .Count(),
+        }
+    )
+
+    assert isinstance(found[0], ast.Lambda)

--- a/tests/test_util_ast.py
+++ b/tests/test_util_ast.py
@@ -1119,13 +1119,19 @@ def test_parse_lambda_multiline_dictionary():
             found.append(parse_as_ast(f))
             return self
 
+    # fmt: off
     my_obj().Select(
+        lambda e: e
+    ).Select(
         lambda particles: {
-            "good": particles.Where(lambda p: p.pdgId() == pdgid).Where(lambda p: p.hasDecayVtx()),
+            "good": particles.Where(lambda p: p.pdgId() == pdgid).Where(
+                lambda p: p.hasDecayVtx()
+            ),
             "none_count": particles.Where(lambda p: p.pdgId() == pdgid)
             .Where(lambda p: not p.hasDecayVtx())
             .Count(),
         }
     )
+    # fmt: on
 
     assert isinstance(found[0], ast.Lambda)


### PR DESCRIPTION
## Summary
- avoid NEWLINE/DEDENT tokens when parsing lambdas
- add regression test for multi-line lambda returning a dictionary

## Testing
- `pytest tests/test_util_ast.py::test_parse_lambda_multiline_dictionary -q`
- `pytest -q`

## Notes:

- `codex` couldn't actually repro the crash - I had to modify the test until it caused a crash. It did correctly code up the fix, however!
- Mitigating circumstances: it was only able to run in a python 3.12 envrionment, not 3.11 or 3.10 where it could trigger the crash.

------
https://chatgpt.com/codex/tasks/task_e_68683cefeff0832085df7a6787d0e722