### PR TITLE
Implement the `in` operator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Instructions for AI agents working in this repo
+
+* Prefer using `Optional[int]` rather than `int | None`.
+* If there is an error the user will see (e.g. `ValueError`), make sure there is enough context in the message for the user. For example, if it is during an expression parse, include the `ast.unparse(a)` in the error message.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ There are several python expressions and idioms that are translated behind your 
 |List Comprehension | `[j.pt() for j in jets if abs(j.eta()) < 2.4]` | `jets.Where(lambda j: abs(j.eta()) < 2.4).Select(lambda j: j.pt())` |
 | Data Classes<br>(typed) | `@dataclass`<br>`class my_data:`<br>`x: ObjectStream[Jets]`<br><br>`Select(lambda e: my_data(x=e.Jets()).x)` | `Select(lambda e: {'x': e.Jets()}.x)` |
 | Named Tuple<br>(typed) | `class my_data(NamedTuple):`<br>`x: ObjectStream[Jets]`<br><br>`Select(lambda e: my_data(x=e.Jets()).x)` | `Select(lambda e: {'x': e.Jets()}.x)` |
+|List Membership|`p.absPdgId() in [35, 51]`|`p.absPdgId() == 35 or p.absPdgId() == 51`|
 
 Note: Everything that goes for a list comprehension also goes for a generator expression.
 

--- a/func_adl/ast/syntatic_sugar.py
+++ b/func_adl/ast/syntatic_sugar.py
@@ -2,7 +2,7 @@ import ast
 import copy
 import inspect
 from dataclasses import is_dataclass
-from typing import Any, List
+from typing import Any, List, Optional
 
 from func_adl.util_ast import lambda_build
 
@@ -105,7 +105,7 @@ def resolve_syntatic_sugar(a: ast.AST) -> ast.AST:
             left = a.left
             right = a.comparators[0]
 
-            def const_list(t: ast.AST) -> List[ast.Constant] | None:
+            def const_list(t: ast.AST) -> Optional[List[ast.Constant]]:
                 if isinstance(t, (ast.List, ast.Tuple)):
                     if all(isinstance(e, ast.Constant) for e in t.elts):
                         return list(t.elts)  # type: ignore

--- a/func_adl/ast/syntatic_sugar.py
+++ b/func_adl/ast/syntatic_sugar.py
@@ -118,10 +118,9 @@ def resolve_syntatic_sugar(a: ast.AST) -> ast.AST:
             elements = const_list(right)
             expr = left
             if elements is None:
-                elements = const_list(left)
-                expr = right
-            if elements is None:
-                return a
+                raise ValueError(
+                    f"Right side of 'in' must be a list or tuple - {ast.unparse(node)}"
+                )
 
             return ast.BoolOp(
                 op=ast.Or(),

--- a/tests/ast/test_syntatic_sugar.py
+++ b/tests/ast/test_syntatic_sugar.py
@@ -254,3 +254,25 @@ def test_resolve_random_class():
     a_resolved = resolve_syntatic_sugar(a)
 
     assert "nt_1(" in ast.unparse(a_resolved)
+
+
+def test_resolve_compare_list_in():
+    a = ast.parse("p.absPdgId() in [35, 51]")
+    a_resolved = resolve_syntatic_sugar(a)
+
+    a_expected = ast.parse("p.absPdgId() == 35 or p.absPdgId() == 51")
+    assert ast.unparse(a_resolved) == ast.unparse(a_expected)
+
+
+def test_resolve_compare_tuple_in():
+    a = ast.parse("p.absPdgId() in (35, 51)")
+    a_resolved = resolve_syntatic_sugar(a)
+
+    a_expected = ast.parse("p.absPdgId() == 35 or p.absPdgId() == 51")
+    assert ast.unparse(a_resolved) == ast.unparse(a_expected)
+
+
+def test_resolve_compare_list_non_constant():
+    a = ast.parse("p.absPdgId() in [x, 51]")
+    with pytest.raises(ValueError, match="All elements"):
+        resolve_syntatic_sugar(a)

--- a/tests/ast/test_syntatic_sugar.py
+++ b/tests/ast/test_syntatic_sugar.py
@@ -276,3 +276,9 @@ def test_resolve_compare_list_non_constant():
     a = ast.parse("p.absPdgId() in [x, 51]")
     with pytest.raises(ValueError, match="All elements"):
         resolve_syntatic_sugar(a)
+
+
+def test_resolve_compare_list_wrong_order():
+    a = ast.parse("[31, 51] in p.absPdgId()")
+    with pytest.raises(ValueError, match="Right side"):
+        resolve_syntatic_sugar(a)


### PR DESCRIPTION
## Summary
- expand `in` comparisons with constant lists or tuples into OR comparisons
- ValueError if the items in the list or tuple aren't constants.
- Update README.md with the new info
- Add `Agents.md` to help future AI's code to the standards here better.


## Testing
- `pytest -q`

Fixes #194

------
https://chatgpt.com/codex/tasks/task_e_686870f4246c83208ac3428d556b8bcd