### PR TITLE
Add sqrt as builtin function

### DIFF
--- a/func_adl/type_based_replacement.py
+++ b/func_adl/type_based_replacement.py
@@ -61,9 +61,11 @@ def _load_default_global_functions():
 
     def my_abs(x: float) -> float: ...  # noqa
     def my_len(x: Iterable) -> int: ...  # noqa
+    def my_sqrt(x: float) -> float: ...  # noqa
 
     _global_functions["abs"] = _FuncAdlFunction("abs", my_abs, None)
     _global_functions["len"] = _FuncAdlFunction("len", my_len, None)
+    _global_functions["sqrt"] = _FuncAdlFunction("sqrt", my_sqrt, None)
 
 
 _load_default_global_functions()

--- a/tests/test_type_based_replacement.py
+++ b/tests/test_type_based_replacement.py
@@ -226,6 +226,20 @@ def test_abs_function_float():
     return_type_test("abs(e)", float, float)
 
 
+def test_sqrt_function_float(caplog):
+    "A call to sqrt with a float"
+    caplog.set_level(logging.WARNING)
+    return_type_test("sqrt(e)", float, float)
+    assert len(caplog.text) == 0
+
+
+def test_sqrt_function_const(caplog):
+    "A call to sqrt with a constant"
+    caplog.set_level(logging.WARNING)
+    return_type_test("sqrt(4)", int, float)
+    assert len(caplog.text) == 0
+
+
 def test_ifexpr_onetype():
     "A ? expression"
     return_type_test("1 if True else 2", int, int)

--- a/tests/test_type_based_replacement_py310.py
+++ b/tests/test_type_based_replacement_py310.py
@@ -212,6 +212,20 @@ def test_abs_function_float():
     return_type_test("abs(e)", float, float)
 
 
+def test_sqrt_function_float(caplog):
+    "A call to sqrt with a float"
+    caplog.set_level(logging.WARNING)
+    return_type_test("sqrt(e)", float, float)
+    assert len(caplog.text) == 0
+
+
+def test_sqrt_function_const(caplog):
+    "A call to sqrt with a constant"
+    caplog.set_level(logging.WARNING)
+    return_type_test("sqrt(4)", int, float)
+    assert len(caplog.text) == 0
+
+
 def test_ifexpr_onetype():
     "A ? expression"
     return_type_test("1 if True else 2", int, int)


### PR DESCRIPTION
## Summary
- register `sqrt` as a default global function so it's properly typed
- test the new `sqrt` mapping on both 3.12 and 3.10 test suites
- capture logging for the `sqrt` tests to ensure no warnings are issued

## Testing
- `flake8`
- `pytest -q`

Fixes #192

------
https://chatgpt.com/codex/tasks/task_e_68687270dbf4832090d239430c0e5d2d