### PR TITLE
Improve dict ifexp error reporting

### DIFF
--- a/func_adl/ast/syntatic_sugar.py
+++ b/func_adl/ast/syntatic_sugar.py
@@ -226,6 +226,7 @@ def resolve_syntatic_sugar(a: ast.AST) -> ast.AST:
                     else:
                         raise ValueError(
                             "Conditional dictionary expansion requires a constant test"
+                            f" - {ast.unparse(e)}"
                         )
                 else:
                     return a

--- a/tests/ast/test_meta_data.py
+++ b/tests/ast/test_meta_data.py
@@ -89,13 +89,9 @@ def test_query_metadata_burried():
 
 
 def test_query_metadata_updated():
-    '''This is testing code in QMetaData, but we need lookup_query_metadata which we are
-    testing in this file'''
-    r = (
-        my_event()
-        .QMetaData({"one": "two"})
-        .QMetaData({"one": "three"})
-    )
+    """This is testing code in QMetaData, but we need lookup_query_metadata which we are
+    testing in this file"""
+    r = my_event().QMetaData({"one": "two"}).QMetaData({"one": "three"})
 
     assert lookup_query_metadata(r, "one") == "three"
 

--- a/tests/ast/test_syntatic_sugar.py
+++ b/tests/ast/test_syntatic_sugar.py
@@ -334,5 +334,26 @@ def test_resolve_dict_star_ifexp_unknown():
         .body[0]
         .value  # type: ignore
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Conditional dictionary"):
         resolve_syntatic_sugar(a)
+
+
+def test_resolve_dict_star_ifexp_nested():
+    """Nested conditional dictionary unpacking should resolve correctly"""
+
+    a = (
+        ast.parse(
+            "{'n': e.EventNumber(), **({'m': e.EventNumber(), **({'o': e.EventNumber()} "
+            "if True else {})} if True else {})}"
+        )
+        .body[0]
+        .value  # type: ignore
+    )
+    a_resolved = resolve_syntatic_sugar(a)
+
+    expected = (
+        ast.parse("{'n': e.EventNumber(), 'm': e.EventNumber(), 'o': e.EventNumber()}")
+        .body[0]
+        .value  # type: ignore
+    )
+    assert ast.unparse(a_resolved) == ast.unparse(expected)

--- a/tests/test_util_types.py
+++ b/tests/test_util_types.py
@@ -314,7 +314,7 @@ def test_get_method_and_class_inherrited_template():
 
     class bogus_1(Generic[T]):
         def fork(self) -> T:
-            ...
+            pass
 
     class bogus_2(bogus_1[int]):
         pass
@@ -325,7 +325,7 @@ def test_get_method_and_class_inherrited_template():
 def test_get_method_and_class_iterable():
     class bogus:
         def fork(self):
-            ...
+            pass
 
     assert get_method_and_class(Iterable[bogus], "fork") is None
 


### PR DESCRIPTION
## Summary
- expand conditional dictionary error message to include failing `if` expression
- ensure unknown conditional merges raise that error in tests
- add nested conditional dictionary merge test
- fix small style issues in util types tests

## Testing
- `black func_adl tests --check`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68696092cf748320b3f683faa95b0b32