### PR TITLE
Improve missing argument error message

### DIFF
--- a/func_adl/type_based_replacement.py
+++ b/func_adl/type_based_replacement.py
@@ -353,7 +353,12 @@ def _fill_in_default_arguments(func: Callable, call: ast.Call) -> Tuple[ast.Call
                     a = as_literal(param.default)
                     arg_array.append(a)
                 else:
-                    raise ValueError(f"Argument {param.name} is required")
+                    func_name: str = getattr(func, "__qualname__", repr(func))
+                    call_source: str = ast.unparse(call)
+                    raise ValueError(
+                        f"Argument '{param.name}' is required when calling "
+                        f"{func_name} via '{call_source}'"
+                    )
 
     # If we are making a change to the call, put in a reference back to the
     # original call.

--- a/tests/test_type_based_replacement.py
+++ b/tests/test_type_based_replacement.py
@@ -296,7 +296,10 @@ def test_required_arg():
     with pytest.raises(ValueError) as e:
         remap_by_types(objs, {"e": Event}, s)
 
-    assert "bank_required" in str(e)
+    message = str(e.value)
+    assert "Argument 'bank_required' is required" in message
+    assert "Event.Jets_req" in message
+    assert "e.Jets_req()" in message
 
 
 def test_collection_with_default():


### PR DESCRIPTION
## Summary
- include the function name and source call when raising the required-argument ValueError so users get actionable context
- assert the detailed error message in the required argument test to demonstrate the new messaging

## Testing
- black --check .
- flake8
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2bbfe5b6083208ac2937947a55a5b