### PR TITLE
3.14 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,31 +12,27 @@ build-backend = "hatchling.build"
 name = "func_adl"
 description = "Functional Analysis Description Language Base Package"
 readme = "README.md"
-authors = [
-    { name = "G. Watts (IRIS-HEP/UW Seattle)", email = "gwatts@uw.edu" }
-]
+authors = [{ name = "G. Watts (IRIS-HEP/UW Seattle)", email = "gwatts@uw.edu" }]
 maintainers = [
-    { name = "Gordon Watts (IRIS-HEP/UW Seattle)", email = "gwatts@uw.edu" }
+    { name = "Gordon Watts (IRIS-HEP/UW Seattle)", email = "gwatts@uw.edu" },
 ]
 license = { text = "MIT" }
-homepage = "https://github.com/iris-hep/func_adl"
 requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Intended Audience :: Information Technology",
     "Programming Language :: Python",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.9",
     "Topic :: Software Development",
-    "Topic :: Utilities"
+    "Topic :: Utilities",
 ]
-dependencies = [
-    "make-it-sync"
-]
+dependencies = ["make-it-sync"]
 dynamic = ["version"]
 
 [project.optional-dependencies]
@@ -52,7 +48,7 @@ test = [
     "black",
     "isort",
     "numpy",
-    "hatch"
+    "hatch",
 ]
 
 [project.scripts]
@@ -66,3 +62,6 @@ include = ["README.md", "/func_adl"]
 
 [tool.hatch.build.targets.wheel]
 include = ["README.md", "/func_adl"]
+
+[project.urls]
+Homepage = "https://github.com/iris-hep/func_adl"


### PR DESCRIPTION
* Add 3.14 to package metadata
* Add 3.14 to the CI build matrix

We've not removed 3.9 - nothing in here is causing it problems. Will remove 3.9 support when we need a python 3.10+ feature.