### PR TITLE
Add `filter`/`map` translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,19 @@ There are several python expressions and idioms that are translated behind your 
 | Named Tuple<br>(typed) | `class my_data(NamedTuple):`<br>`x: ObjectStream[Jets]`<br><br>`Select(lambda e: my_data(x=e.Jets()).x)` | `Select(lambda e: {'x': e.Jets()}.x)` |
 |List Membership|`p.absPdgId() in [35, 51]`|`p.absPdgId() == 35 or p.absPdgId() == 51`|
 | `any`/`all` | `any([e.pt() > 10, abs(e.eta()) < 2.5])` | `e.pt() > 10 or abs(e.eta()) < 2.5` |
+| `filter` | `filter(lambda j: j.pt() > 30, jets)` | `jets.Where(lambda j: j.pt() > 30)` |
+| `map` | `map(lambda j: j.pt(), jets)` | `jets.Select(lambda j: j.pt())` |
 
 Note: Everything that goes for a list comprehension also goes for a generator expression.
 
 For `any`/`all`, generator/list comprehensions over a literal (or captured literal constant)
 are first expanded to a literal list and then reduced as usual. For example,
 `any(f(a) for a in [1, 2])` is treated like `any([f(1), f(2)])`.
+
+For `filter`/`map`, only the builtin two-argument form is supported in syntatic sugar:
+`filter(func, seq)` and `map(func, seq)`. Keyword arguments are rejected with a
+contextual error message so the unsupported expression is easy to identify.
+
 
 ## Extensibility
 

--- a/docs/source/generic/query_structure.md
+++ b/docs/source/generic/query_structure.md
@@ -43,6 +43,10 @@ expressions:
 - List comprehensions over literal iterables are expanded directly. For example,
   `[i for i in [1, 2, 3]]` becomes `[1, 2, 3]`.
 - `any`/`all` over literal lists/tuples are reduced to boolean `or`/`and` expressions.
+- builtin `filter(func, seq)` and `map(func, seq)` are lowered to
+  `seq.Where(func)` and `seq.Select(func)`.
 
 This means patterns like `any(expr(x) for x in LITERAL_LIST)` can be simplified in-query,
-as long as the iterable is a literal (or a captured literal constant).
+as long as the iterable is a literal (or a captured literal constant). Likewise,
+`filter(lambda j: j.pt() > 30, jets)` and `map(lambda j: j.pt(), jets)` can be
+written in query lambdas and translated to the corresponding query operators.


### PR DESCRIPTION
### Motivation
- Ensure that lowering builtin `filter(func, seq)` and `map(func, seq)` to query operators does not prevent other syntactic-sugar transforms (e.g. `any`/`all` reductions) from running on the rewritten tree.
- Provide clear errors for unsupported `filter`/`map` signatures and document the supported forms in the README and docs.

### Description
- Add `_resolve_filter_map_call` in `func_adl/ast/syntatic_sugar.py` to detect and lower `filter`/`map` to `seq.Where(lambda...)` / `seq.Select(lambda...)`, including validation for keyword args, arity, and requiring a `lambda` transform argument.
- In the `visit_Call` flow in `func_adl/ast/syntatic_sugar.py`, revisit the lowered `filter`/`map` result with `self.visit(...)` so subsequent syntactic-sugar transforms can still operate on the rewritten AST.
- Add tests in `tests/ast/test_syntatic_sugar.py` covering lambda and captured-callable lowering, invalid signature error paths, and a regression test verifying that `any`/`all` sugar still applies inside a `map(...)` lambda after lowering.
- Update documentation in `README.md` and `docs/source/generic/query_structure.md` to describe the `filter`/`map` lowering and the supported two-argument builtin forms and signature expectations.

### Testing
- Ran `pytest -q` and all tests passed: `440 passed`.
- Ran `black --check func_adl tests` and it succeeded with no reformatting needed after adjustments.
- Ran `flake8 func_adl tests` with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69904a3803808320ae55d0e2cb26927c)