### PR TITLE
Dupport translation from dict comprehension as syntatic sugar

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ There are several python expressions and idioms that are translated behind your 
 |Multi-generator comprehension|`[j.pt() + e.pt() for j in jets for e in electrons]`|`jets.SelectMany(lambda j: electrons.Select(lambda e: j.pt() + e.pt()))`|
 |Destructuring List Comprehension|`[a+b for a,b in pairs]`|`pairs.Select(lambda tmp: tmp[0] + tmp[1])`|
 |Literal List Comprehension|`[i for i in [1, 2, 3]]`|`[1, 2, 3]`|
+|Dictionary Comprehension|`{j.id(): j.pt() for j in jets}`|`jets.Select(lambda j: {'key': j.id(), 'value': j.pt()})`|
+|Dictionary Comprehension (with filter)|`{j.id(): j.pt() for j in jets if j.pt() > 100}`|`jets.Where(lambda j: j.pt() > 100).Select(lambda j: {'key': j.id(), 'value': j.pt()})`|
+|Literal Dictionary Comprehension|`{i: i * 2 for i in [1, 2, 3]}`|`{1: 1 * 2, 2: 2 * 2, 3: 3 * 2}`|
 | Data Classes<br>(typed) | `@dataclass`<br>`class my_data:`<br>`x: ObjectStream[Jets]`<br><br>`Select(lambda e: my_data(x=e.Jets()).x)` | `Select(lambda e: {'x': e.Jets()}.x)` |
 | Named Tuple<br>(typed) | `class my_data(NamedTuple):`<br>`x: ObjectStream[Jets]`<br><br>`Select(lambda e: my_data(x=e.Jets()).x)` | `Select(lambda e: {'x': e.Jets()}.x)` |
 |List Membership|`p.absPdgId() in [35, 51]`|`p.absPdgId() == 35 or p.absPdgId() == 51`|

--- a/docs/source/generic/query_structure.md
+++ b/docs/source/generic/query_structure.md
@@ -47,6 +47,11 @@ expressions:
   value (for example, `[a+b for a,b in pairs]` behaves like `pairs.Select(lambda tmp: tmp[0] + tmp[1])`).
 - List comprehensions over literal iterables are expanded directly. For example,
   `[i for i in [1, 2, 3]]` becomes `[1, 2, 3]`.
+- Dictionary comprehensions over streams are lowered to `.Select(...)` of
+  key/value records (e.g. `{'key': ..., 'value': ...}`), including `.Where(...)`
+  when comprehension `if` filters are present.
+- Dictionary comprehensions over literal iterables are expanded directly into
+  dictionary literals.
 - `any`/`all` over literal lists/tuples are reduced to boolean `or`/`and` expressions.
 - builtin `filter(func, seq)` and `map(func, seq)` are lowered to
   `seq.Where(func)` and `seq.Select(func)`.

--- a/tests/ast/test_syntatic_sugar.py
+++ b/tests/ast/test_syntatic_sugar.py
@@ -30,6 +30,33 @@ def test_resolve_generator():
     assert ast.dump(ast.parse("jets.Select(lambda j: j.pt())")) == ast.dump(a_new)
 
 
+def test_resolve_dictcomp():
+    a = ast.parse("{j.id(): j.pt() for j in jets}")
+    a_new = resolve_syntatic_sugar(a)
+
+    assert ast.dump(
+        ast.parse("jets.Select(lambda j: {'key': j.id(), 'value': j.pt()})")
+    ) == ast.dump(a_new)
+
+
+def test_resolve_dictcomp_if():
+    a = ast.parse("{j.id(): j.pt() for j in jets if j.pt() > 100}")
+    a_new = resolve_syntatic_sugar(a)
+
+    assert ast.dump(
+        ast.parse(
+            "jets.Where(lambda j: j.pt() > 100).Select(lambda j: {'key': j.id(), 'value': j.pt()})"
+        )
+    ) == ast.dump(a_new)
+
+
+def test_resolve_literal_dict_comp():
+    a = ast.parse("{i: i * 2 for i in [1, 2, 3]}")
+    a_new = resolve_syntatic_sugar(a)
+
+    assert ast.dump(ast.parse("{1: 1 * 2, 2: 2 * 2, 3: 3 * 2}")) == ast.dump(a_new)
+
+
 def test_resolve_literal_list_comp():
     a = ast.parse("[i for i in [1, 2, 3]]")
     a_new = resolve_syntatic_sugar(a)


### PR DESCRIPTION
### Motivation
- Implement dictionary-comprehensions as syntatic sugar
- Make the new dictionary-comprehension lowering behavior discoverable to users by documenting how dict comprehensions are rewritten into query operators and when they are inlined as literals.

### Description
- Add dictionary-comprehension examples to the README `Syntatic Sugar` table in `README.md`, including base lowering, `if`-filtered lowering, and literal inlining examples. 
- Update `docs/source/generic/query_structure.md` to describe that dictionary comprehensions over streams are lowered to `.Select(...)` of key/value records (with `.Where(...)` when filters are present) and that literal dict comprehensions are expanded into dictionary literals.

### Testing
- Ran `pytest -q` and all tests passed (`437 passed`).
- Ran `black --check func_adl tests docs` which succeeded with no formatting changes and ran `flake8 func_adl tests` with no lint errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69904a0827b483208d89b1ebe3896632)