### PR TITLE
Add python `min`/`max` syntatic sugar

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ There are several python expressions and idioms that are translated behind your 
 | `filter` | `filter(lambda j: j.pt() > 30, jets)` | `jets.Where(lambda j: j.pt() > 30)` |
 | `map` | `map(lambda j: j.pt(), jets)` | `jets.Select(lambda j: j.pt())` |
 | `sum` over comprehension | `sum(j.pt() for j in jets)` | `Sum(jets.Select(lambda j: j.pt()))` |
+| `min`/`max` | `max(j.pt() for j in jets if abs(j.eta()) < 2.4)` | `Max(jets.Where(lambda j: abs(j.eta()) < 2.4).Select(lambda j: j.pt()))` |
 
 Note: Everything that goes for a list comprehension also goes for a generator expression.
 
@@ -79,6 +80,10 @@ contextual error message so the unsupported expression is easy to identify.
 `sum` with a single list/generator comprehension argument is rewritten to `Sum(...)`
 after the comprehension is lowered to `Select(...)`, e.g.
 `sum(j.pt() for j in jets)` becomes `Sum(jets.Select(lambda j: j.pt()))`.
+
+For `min`/`max`, when the single argument is a list/generator comprehension, FuncADL first
+lowers that comprehension to query operators and then wraps the result in `Min(...)`/`Max(...)`
+so aggregate simplification can process it.
 
 ## Extensibility
 

--- a/docs/source/generic/query_structure.md
+++ b/docs/source/generic/query_structure.md
@@ -46,9 +46,8 @@ expressions:
 - builtin `filter(func, seq)` and `map(func, seq)` are lowered to
   `seq.Where(func)` and `seq.Select(func)`.
 - `sum` with a single list/generator comprehension argument is lowered to `Sum(Select(...))`.
- - builtin `filter(func, seq)` and `map(func, seq)` are lowered to
-   `seq.Where(func)` and `seq.Select(func)`.
- - `sum` with a single list/generator comprehension argument is lowered to `Sum(Select(...))`.
+- `min`/`max` with a single list/generator-comprehension argument are lowered to
+  `Min(...)`/`Max(...)` after the comprehension itself is lowered.
 
 This means patterns like `any(expr(x) for x in LITERAL_LIST)` can be simplified in-query,
 as long as the iterable is a literal (or a captured literal constant). Likewise,
@@ -57,4 +56,6 @@ written in query lambdas and translated to the corresponding query operators.
 
 Similarly, aggregate expressions such as `sum(j.pt() for j in jets)` are translated into
 query-style aggregate calls (`Sum(jets.Select(lambda j: j.pt()))`) that downstream
-aggregate lowering can process.
+aggregate lowering can process. The same applies to `min`/`max`: expressions like
+`max(expr(x) for x in stream if pred(x))` are rewritten to the aggregate form
+`Max(stream.Where(lambda x: pred(x)).Select(lambda x: expr(x)))`.

--- a/tests/ast/test_syntatic_sugar.py
+++ b/tests/ast/test_syntatic_sugar.py
@@ -563,6 +563,36 @@ def test_resolve_any_call_keeps_nested_sum_rewrite():
     assert ast.unparse(a_resolved) == ast.unparse(a_expected)
 
 
+def test_resolve_min_generator_to_min_call():
+    a = ast.parse("min(j.pt() for j in e.jets)")
+    a_resolved = resolve_syntatic_sugar(a)
+
+    a_expected = ast.parse("Min(e.jets.Select(lambda j: j.pt()))")
+    assert ast.unparse(a_resolved) == ast.unparse(a_expected)
+
+
+def test_resolve_max_list_comprehension_to_max_call():
+    a = ast.parse("max([j.pt() for j in e.jets if j.eta() < 2.4])")
+    a_resolved = resolve_syntatic_sugar(a)
+
+    a_expected = ast.parse("Max(e.jets.Where(lambda j: j.eta() < 2.4).Select(lambda j: j.pt()))")
+    assert ast.unparse(a_resolved) == ast.unparse(a_expected)
+
+
+def test_resolve_min_comprehension_invalid_signature():
+    a = ast.parse("min((j.pt() for j in e.jets), default=0)")
+
+    with pytest.raises(ValueError, match="requires exactly one positional argument"):
+        resolve_syntatic_sugar(a)
+
+
+def test_resolve_max_comprehension_invalid_signature_extra_positional():
+    a = ast.parse("max((j.pt() for j in e.jets), 0)")
+
+    with pytest.raises(ValueError, match="requires exactly one positional argument"):
+        resolve_syntatic_sugar(a)
+
+
 def test_resolve_nested_captured_function_in_list_comp():
     bib_triggers = [(1, 2), (3, 4)]
 


### PR DESCRIPTION
### Motivation
- Make behavior explicit in docs that builtin `min`/`max` called with a single list/generator comprehension lowers to `Min(...)`/`Max(...)` so aggregate simplification can process them.
- Add tests to cover both successful lowering and invalid signature cases for `min`/`max` when used with comprehensions.

### Description
- Added `_resolve_min_max_call` to `func_adl/ast/syntatic_sugar.py` to detect `min`/`max` calls on comprehensions, validate signatures, and return `Min(...)`/`Max(...)` AST calls.
- Wired the new resolver into the call handling in `resolve_syntatic_sugar` so it runs after the existing `any`/`all` lowering.
- Updated documentation in `README.md` and `docs/source/generic/query_structure.md` to describe the `min`/`max` lowering and show an example aggregate-form rewrite using `Max(...)`.
- Extended `tests/ast/test_syntatic_sugar.py` with positive tests for `min`/`max` lowering and additional negative tests asserting invalid signatures raise `ValueError`.

### Testing
- Ran `pytest -q tests/ast/test_syntatic_sugar.py` and it succeeded (`46 passed`).
- Ran the full suite with `pytest -q` and it succeeded (`438 passed`).
- Ran `black --check func_adl tests` and it succeeded, while `black --check` that included `README.md` and the modified markdown docs failed due to Black parsing those markdown files as Python (markdown files are not targeted by `black`), so code and tests remain formatted.
- Ran `flake8 func_adl tests` and it succeeded with no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699049a5e1b0832099fb0025842d9208)