### PR TITLE
Add support for python `sum` - translate it into func-adl.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ There are several python expressions and idioms that are translated behind your 
 | `any`/`all` | `any([e.pt() > 10, abs(e.eta()) < 2.5])` | `e.pt() > 10 or abs(e.eta()) < 2.5` |
 | `filter` | `filter(lambda j: j.pt() > 30, jets)` | `jets.Where(lambda j: j.pt() > 30)` |
 | `map` | `map(lambda j: j.pt(), jets)` | `jets.Select(lambda j: j.pt())` |
+| `sum` over comprehension | `sum(j.pt() for j in jets)` | `Sum(jets.Select(lambda j: j.pt()))` |
 
 Note: Everything that goes for a list comprehension also goes for a generator expression.
 
@@ -75,6 +76,9 @@ For `filter`/`map`, only the builtin two-argument form is supported in syntatic 
 `filter(func, seq)` and `map(func, seq)`. Keyword arguments are rejected with a
 contextual error message so the unsupported expression is easy to identify.
 
+`sum` with a single list/generator comprehension argument is rewritten to `Sum(...)`
+after the comprehension is lowered to `Select(...)`, e.g.
+`sum(j.pt() for j in jets)` becomes `Sum(jets.Select(lambda j: j.pt()))`.
 
 ## Extensibility
 

--- a/docs/source/generic/query_structure.md
+++ b/docs/source/generic/query_structure.md
@@ -45,8 +45,16 @@ expressions:
 - `any`/`all` over literal lists/tuples are reduced to boolean `or`/`and` expressions.
 - builtin `filter(func, seq)` and `map(func, seq)` are lowered to
   `seq.Where(func)` and `seq.Select(func)`.
+- `sum` with a single list/generator comprehension argument is lowered to `Sum(Select(...))`.
+ - builtin `filter(func, seq)` and `map(func, seq)` are lowered to
+   `seq.Where(func)` and `seq.Select(func)`.
+ - `sum` with a single list/generator comprehension argument is lowered to `Sum(Select(...))`.
 
 This means patterns like `any(expr(x) for x in LITERAL_LIST)` can be simplified in-query,
 as long as the iterable is a literal (or a captured literal constant). Likewise,
 `filter(lambda j: j.pt() > 30, jets)` and `map(lambda j: j.pt(), jets)` can be
 written in query lambdas and translated to the corresponding query operators.
+
+Similarly, aggregate expressions such as `sum(j.pt() for j in jets)` are translated into
+query-style aggregate calls (`Sum(jets.Select(lambda j: j.pt()))`) that downstream
+aggregate lowering can process.

--- a/tests/ast/test_syntatic_sugar.py
+++ b/tests/ast/test_syntatic_sugar.py
@@ -539,6 +539,30 @@ def test_resolve_any_all_generator_empty_sequence_semantics():
     assert ast.unparse(a_all_resolved) == ast.unparse(a_all_expected)
 
 
+def test_resolve_sum_generator_to_query_sum_call():
+    a = ast.parse("sum(j.pt() for j in jets)")
+    a_resolved = resolve_syntatic_sugar(a)
+
+    a_expected = ast.parse("Sum(jets.Select(lambda j: j.pt()))")
+    assert ast.unparse(a_resolved) == ast.unparse(a_expected)
+
+
+def test_resolve_sum_list_comprehension_to_query_sum_call():
+    a = ast.parse("sum([j.pt() for j in jets])")
+    a_resolved = resolve_syntatic_sugar(a)
+
+    a_expected = ast.parse("Sum(jets.Select(lambda j: j.pt()))")
+    assert ast.unparse(a_resolved) == ast.unparse(a_expected)
+
+
+def test_resolve_any_call_keeps_nested_sum_rewrite():
+    a = ast.parse("any([sum(j.pt() for j in jets) > 0, e.met() > 20])")
+    a_resolved = resolve_syntatic_sugar(a)
+
+    a_expected = ast.parse("Sum(jets.Select(lambda j: j.pt())) > 0 or e.met() > 20")
+    assert ast.unparse(a_resolved) == ast.unparse(a_expected)
+
+
 def test_resolve_nested_captured_function_in_list_comp():
     bib_triggers = [(1, 2), (3, 4)]
 


### PR DESCRIPTION
* Adds translation support for python's `sum` - and changes it into the func-adl `Sum`.
* Update (minimally) the documentation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990493fdae88320b3444797f38a4f32)