### PR TITLE
Translate multigenerator expressions (`[x.pt()+y.pt() for x in jets for y in electrons]`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ There are several python expressions and idioms that are translated behind your 
 --- | --- | --- |
 |List Comprehension | `[j.pt() for j in jets]` | `jets.Select(lambda j: j.pt())` |
 |List Comprehension | `[j.pt() for j in jets if abs(j.eta()) < 2.4]` | `jets.Where(lambda j: abs(j.eta()) < 2.4).Select(lambda j: j.pt())` |
+|Multi-generator comprehension|`[j.pt() + e.pt() for j in jets for e in electrons]`|`jets.SelectMany(lambda j: electrons.Select(lambda e: j.pt() + e.pt()))`|
 |Literal List Comprehension|`[i for i in [1, 2, 3]]`|`[1, 2, 3]`|
 | Data Classes<br>(typed) | `@dataclass`<br>`class my_data:`<br>`x: ObjectStream[Jets]`<br><br>`Select(lambda e: my_data(x=e.Jets()).x)` | `Select(lambda e: {'x': e.Jets()}.x)` |
 | Named Tuple<br>(typed) | `class my_data(NamedTuple):`<br>`x: ObjectStream[Jets]`<br><br>`Select(lambda e: my_data(x=e.Jets()).x)` | `Select(lambda e: {'x': e.Jets()}.x)` |
@@ -68,6 +69,9 @@ There are several python expressions and idioms that are translated behind your 
 | `min`/`max` | `max(j.pt() for j in jets if abs(j.eta()) < 2.4)` | `Max(jets.Where(lambda j: abs(j.eta()) < 2.4).Select(lambda j: j.pt()))` |
 
 Note: Everything that goes for a list comprehension also goes for a generator expression.
+
+For multi-generator comprehensions (`for ... for ...`), lowering always preserves Python
+iteration semantics by flattening one level with `SelectMany` at outer generator levels.
 
 For `any`/`all`, generator/list comprehensions over a literal (or captured literal constant)
 are first expanded to a literal list and then reduced as usual. For example,

--- a/docs/source/generic/query_structure.md
+++ b/docs/source/generic/query_structure.md
@@ -39,7 +39,9 @@ Due to the flexible nature of FuncADL there are multiple ways to structure each 
 Inside query lambdas, FuncADL also rewrites a few common Python forms into query-friendly
 expressions:
 
-- List/generator comprehensions over streams are lowered to `.Where(...)`/`.Select(...)`.
+- List/generator comprehensions over streams are lowered to query operators.
+  Multi-generator forms (`for ... for ...`) flatten outer levels via `.SelectMany(...)`
+  so the stream shape matches Python iteration semantics.
 - List comprehensions over literal iterables are expanded directly. For example,
   `[i for i in [1, 2, 3]]` becomes `[1, 2, 3]`.
 - `any`/`all` over literal lists/tuples are reduced to boolean `or`/`and` expressions.


### PR DESCRIPTION
### Motivation
- Support multigenerator expressions as syntatic sugar

### Description
- Add `test_resolve_3generator_list_comp_flattened_shape` to `tests/ast/test_syntatic_sugar.py` which asserts a comprehension like `[j.pt()+e.pt()+m.pt() for j in jets for e in electrons for m in muons]` lowers to `jets.SelectMany(lambda j: electrons.SelectMany(lambda e: muons.Select(lambda m: j.pt()+e.pt()+m.pt())))`.

### Testing
- Ran `pytest -q tests/ast/test_syntatic_sugar.py` (44 passed) and the full suite with `pytest -q` (436 passed), and verified `black --check func_adl tests` and `flake8 func_adl tests` completed with no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699049e130cc8320b65843113e60f26a)